### PR TITLE
mrc-665: add a proxy to the constellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Options:
 ```
 <!-- Usage end -->
 
+## Proxy & SSL
+
+For now, we're going to use self-signed certificates for `naomi.dide.ic.ac.uk`, which we will replace with more reasonable certificates later.  Certificates are generated during start-up of the proxy container.
+
 ## License
 
 MIT © Imperial College of Science, Technology and Medicine

--- a/config/hint.yml
+++ b/config/hint.yml
@@ -13,6 +13,11 @@ hint:
 hintr:
   tag: "master"
 
+proxy:
+  host: localhost
+  # port_http: 80
+  # port_https: 443
+
 docker:
   network: hint_nw
   default_tag: master


### PR DESCRIPTION
This PR will add a basic nginx proxy to the constellation. Currently this uses only a self-signed certificate, hopefully @weshinsley can organise us a real cert and later we can update it with the proper hostname (mrc-666).

(We need a real cert up so that we can get ICT to open ports, etc).