### PR TITLE
mrc-655: support for running with simulated slow connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ Options:
 ```
 <!-- Usage end -->
 
+## Simulate slow connections
+
+For testing performance, connect the application to [toxiproxy](https://toxiproxy.io) by running
+
+```
+./scripts/slow
+```
+
+and then connect to http://localhost:8081
+
+The bandwidth and latency of the connection will be affected - see `./scripts/slow --help` for details.
+
 ## License
 
 MIT © Imperial College of Science, Technology and Medicine

--- a/scripts/slow
+++ b/scripts/slow
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+Usage:
+  ./scripts/slow start [options]
+  ./scripts/slow stop
+  ./scripts/slow status
+
+Options:
+  --bandwidth=RATE  Bandwidth, in KB/s [default: 100]
+  --latency=TIME    Latency, in ms [default: 50]
+"""
+
+import docker
+import docopt
+import hvac
+
+from constellation import docker_util
+
+CONTAINER_NAME = "hint_toxiproxy"
+CLI = "/go/bin/toxiproxy-cli"
+
+
+def start(bandwidth, latency):
+    if docker_util.container_exists(CONTAINER_NAME):
+        print("toxiproxy already running")
+        exit(1)
+
+    print("Creating container")
+    cl = docker.client.from_env()
+    tox = cl.containers.run("shopify/toxiproxy:2.1.4", name=CONTAINER_NAME,
+                            ports={"8081/tcp": 8081}, auto_remove=True,
+                            detach=True)
+
+    print("Creating proxy")
+    # Create a toxiproxy
+    args = [CLI, "create", "hint", "--listen",
+            "0.0.0.0:8081", "--upstream", "hint:8080"]
+    docker_util.exec_safely(tox, args)
+
+    print("Configuring proxy")
+    for direction in ["--upstream", "--downstream"]:
+        args = [CLI, "toxic", "add", "hint", "--type", "bandwidth",
+                direction, "-a", "rate={}".format(bandwidth)]
+        docker_util.exec_safely(tox, args)
+
+    args = [CLI, "toxic", "add", "hint", "--type", "latency",
+            direction, "-a", "latency={}".format(latency)]
+    docker_util.exec_safely(tox, args)
+
+    inspect()
+
+
+def inspect():
+    tox = docker.client.from_env().containers.get(CONTAINER_NAME)
+    res = docker_util.exec_safely(tox, [CLI, "inspect", "hint"])
+    print(res.output.decode("UTF-8"))
+
+
+def stop():
+    if docker_util.container_exists(CONTAINER_NAME):
+        print("Stopping container")
+        docker.client.from_env().containers.get(CONTAINER_NAME).kill()
+
+
+def status():
+    if docker_util.container_exists(CONTAINER_NAME):
+        print("toxiproxy: running")
+        inspect()
+    else:
+        print("toxiproxy: stopped")
+
+
+def main():
+    args = docopt.docopt(__doc__)
+    if args["start"]:
+        start(int(args["--bandwidth"]), int(args["--latency"]))
+    elif args["stop"]:
+        stop()
+    else:
+        status()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/slow
+++ b/scripts/slow
@@ -29,12 +29,12 @@ def start(bandwidth, latency):
     cl = docker.client.from_env()
     tox = cl.containers.run("shopify/toxiproxy:2.1.4", name=CONTAINER_NAME,
                             ports={"8081/tcp": 8081}, auto_remove=True,
-                            detach=True)
+                            network="host", detach=True)
 
     print("Creating proxy")
     # Create a toxiproxy
     args = [CLI, "create", "hint", "--listen",
-            "0.0.0.0:8081", "--upstream", "hint:8080"]
+            "0.0.0.0:8081", "--upstream", "localhost:8080"]
     docker_util.exec_safely(tox, args)
 
     print("Configuring proxy")


### PR DESCRIPTION
This PR will add support for using [toxiproxy](https://toxiproxy.io) to simulate slower connections, for use in testing.

I've not added this as an explicit container to the constellation, but we could do that later if it feels more natural - the bulk of the `start` function would become a configure function.  The blocking issue on doing this is creating support for different configurations for production and testing, really.  This way also makes it easy to use the slow proxy outside of a full deployment, e.g., in development of hint itself.  It will affect whatever is running on port 8080 on the host.