### PR TITLE
mrc-677: add ssl certs to the deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
 
 script:
   # This line is required until we push constellation up onto pypi
-  - pip3 install git+https://github.com/reside-ic/constellation@reside-48#egg=constellation
+  - pip3 install git+https://github.com/reside-ic/constellation@reside-57#egg=constellation
   - pip3 install -r requirements.txt
   - pytest --cov=src
   - pycodestyle .

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ install:
   - pip3 install pytest-cov pycodestyle codecov
 
 script:
-  # This line is required until we push constellation up onto pypi
-  - pip3 install git+https://github.com/reside-ic/constellation@reside-57#egg=constellation
+  # This line is required if using a branch of constellation:
+  # - pip3 install git+https://github.com/reside-ic/constellation@reside-57#egg=constellation
   - pip3 install -r requirements.txt
   - pytest --cov=src
   - pycodestyle .

--- a/config/production.yml
+++ b/config/production.yml
@@ -1,0 +1,12 @@
+proxy:
+  host: naomi.dide.ic.ac.uk
+  port_http: 80
+  port_https: 443
+  ssl:
+    certificate: VAULT:secret/hint/ssl/naomi:certificate
+    key: VAULT:secret/hint/ssl/naomi:key
+
+vault:
+  addr: https://vault.dide.ic.ac.uk:8200
+  auth:
+    method: github

--- a/config/staging.yml
+++ b/config/staging.yml
@@ -1,0 +1,12 @@
+proxy:
+  host: naomi.dide.ic.ac.uk
+  port_http: 10080
+  port_https: 10443
+  ssl:
+    certificate: VAULT:secret/hint/ssl/naomi:certificate
+    key: VAULT:secret/hint/ssl/naomi:key
+
+vault:
+  addr: https://vault.dide.ic.ac.uk:8200
+  auth:
+    method: github

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-constellation
+constellation==0.0.3
 docopt
 pytest
 requests

--- a/src/hint_cli.py
+++ b/src/hint_cli.py
@@ -1,6 +1,6 @@
 """
 Usage:
-  ./hint start [--pull]
+  ./hint start [--pull] [<config>]
   ./hint stop  [--volumes] [--network] [--kill] [--force]
   ./hint destroy
   ./hint status
@@ -22,9 +22,11 @@ from src.hint_deploy import HintConfig, hint_constellation, hint_user
 
 def parse(argv=None):
     path = "config"
+    config = None
     dat = docopt.docopt(__doc__, argv)
     if dat["start"]:
         action = "start"
+        config = dat["<config>"]
         args = {"pull_images": dat["--pull"]}
     elif dat["stop"]:
         action = "stop"
@@ -51,12 +53,12 @@ def parse(argv=None):
                 "action": user_action,
                 "pull": dat["--pull"],
                 "password": dat["<password>"]}
-    return path, action, args
+    return path, config, action, args
 
 
 def main(argv=None):
-    path, action, args = parse(argv)
-    cfg = HintConfig(path)
+    path, config, action, args = parse(argv)
+    cfg = HintConfig(path, config)
     if action == "user":
         hint_user(cfg, **args)
     else:

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -11,8 +11,9 @@ import constellation.docker_util as docker_util
 
 
 class HintConfig:
-    def __init__(self, path):
+    def __init__(self, path, extra=None):
         dat = config.read_yaml("{}/hint.yml".format(path))
+        dat = config.config_build(path, dat, extra)
         self.network = config.config_string(dat, ["docker", "network"])
         self.prefix = config.config_string(dat, ["docker", "prefix"])
         default_tag = config.config_string(dat, ["docker", "default_tag"],

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -36,9 +36,14 @@ class HintConfig:
         self.proxy_port_https = config.config_integer(dat,
                                                       ["proxy", "port_https"],
                                                       True, 443)
+        self.proxy_ssl_certificate = config.config_string(
+            dat, ["proxy", "ssl", "certificate"], True)
+        self.proxy_ssl_key = config.config_string(
+            dat, ["proxy", "ssl", "key"], True)
         self.volumes = {
             "db": config.config_string(dat, ["db", "volume"]),
             "uploads": config.config_string(dat, ["hint", "volume"])}
+        self.vault = config.config_vault(dat, ["vault"])
 
 
 def hint_constellation(cfg):
@@ -87,7 +92,8 @@ def hint_constellation(cfg):
     containers = [db, redis, hintr, hint, proxy]
 
     obj = constellation.Constellation("hint", cfg.prefix, containers,
-                                      cfg.network, cfg.volumes, cfg)
+                                      cfg.network, cfg.volumes,
+                                      data=cfg, vault_config=cfg.vault)
 
     return obj
 
@@ -134,10 +140,17 @@ def hint_configure(container, cfg):
 
 def proxy_configure(container, cfg):
     print("[proxy] Configuring proxy")
-    print("Generating self-signed certificates for proxy")
-    args = ["self-signed-certificate", "/run/proxy",
-            "GB", "London", "IC", "reside", cfg.proxy_host]
-    docker_util.exec_safely(container, args)
+    if cfg.proxy_ssl_certificate and cfg.proxy_ssl_key:
+        print("Copying ssl certificate and key into proxy")
+        docker_util.string_into_container(cfg.proxy_ssl_certificate, container,
+                                          "/run/proxy/certificate.pem")
+        docker_util.string_into_container(cfg.proxy_ssl_key, container,
+                                          "/run/proxy/key.pem")
+    else:
+        print("Generating self-signed certificates for proxy")
+        args = ["self-signed-certificate", "/run/proxy",
+                "GB", "London", "IC", "reside", cfg.proxy_host]
+        docker_util.exec_safely(container, args)
 
 
 # It can take a while for the container to come up

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -8,37 +8,39 @@ from src import hint_deploy
 
 def test_cli_parse():
     assert hint_cli.parse(["start"]) == \
-        ("config", "start", {"pull_images": False})
+        ("config", None, "start", {"pull_images": False})
     assert hint_cli.parse(["start", "--pull"]) == \
-        ("config", "start", {"pull_images": True})
+        ("config", None, "start", {"pull_images": True})
+    assert hint_cli.parse(["start", "staging"]) == \
+        ("config", "staging", "start", {"pull_images": False})
 
     assert hint_cli.parse(["stop"]) == \
-        ("config", "stop", {"kill": False, "remove_network": False,
+        ("config", None, "stop", {"kill": False, "remove_network": False,
                             "remove_volumes": False})
     assert hint_cli.parse(["stop", "--kill", "--network"]) == \
-        ("config", "stop", {"kill": True, "remove_network": True,
+        ("config", None, "stop", {"kill": True, "remove_network": True,
                             "remove_volumes": False})
 
     assert hint_cli.parse(["destroy"]) == \
-        ("config", "stop", {"kill": True, "remove_network": True,
+        ("config", None, "stop", {"kill": True, "remove_network": True,
                             "remove_volumes": True})
 
-    assert hint_cli.parse(["status"]) == ("config", "status", {})
+    assert hint_cli.parse(["status"]) == ("config", None, "status", {})
 
     email = "user@example.com"
     password = "password"
     assert hint_cli.parse(["user", "add", email]) == \
-        ("config", "user", {"email": email, "action": "add-user",
+        ("config", None, "user", {"email": email, "action": "add-user",
                             "pull": False, password: None})
     assert hint_cli.parse(["user", "add", "--pull", email, password]) == \
-        ("config", "user", {"email": email, "action": "add-user",
+        ("config", None, "user", {"email": email, "action": "add-user",
                             "pull": True, password: password})
 
     assert hint_cli.parse(["user", "exists", email]) == \
-        ("config", "user", {"email": email, "action": "user-exists",
+        ("config", None, "user", {"email": email, "action": "user-exists",
                             "pull": False, password: None})
     assert hint_cli.parse(["user", "remove", email]) == \
-        ("config", "user", {"email": email, "action": "remove-user",
+        ("config", None, "user", {"email": email, "action": "remove-user",
                             "pull": False, password: None})
 
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -16,14 +16,14 @@ def test_cli_parse():
 
     assert hint_cli.parse(["stop"]) == \
         ("config", None, "stop", {"kill": False, "remove_network": False,
-                            "remove_volumes": False})
+                                  "remove_volumes": False})
     assert hint_cli.parse(["stop", "--kill", "--network"]) == \
         ("config", None, "stop", {"kill": True, "remove_network": True,
-                            "remove_volumes": False})
+                                  "remove_volumes": False})
 
     assert hint_cli.parse(["destroy"]) == \
         ("config", None, "stop", {"kill": True, "remove_network": True,
-                            "remove_volumes": True})
+                                  "remove_volumes": True})
 
     assert hint_cli.parse(["status"]) == ("config", None, "status", {})
 
@@ -31,17 +31,17 @@ def test_cli_parse():
     password = "password"
     assert hint_cli.parse(["user", "add", email]) == \
         ("config", None, "user", {"email": email, "action": "add-user",
-                            "pull": False, password: None})
+                                  "pull": False, password: None})
     assert hint_cli.parse(["user", "add", "--pull", email, password]) == \
         ("config", None, "user", {"email": email, "action": "add-user",
-                            "pull": True, password: password})
+                                  "pull": True, password: password})
 
     assert hint_cli.parse(["user", "exists", email]) == \
         ("config", None, "user", {"email": email, "action": "user-exists",
-                            "pull": False, password: None})
+                                  "pull": False, password: None})
     assert hint_cli.parse(["user", "remove", email]) == \
         ("config", None, "user", {"email": email, "action": "remove-user",
-                            "pull": False, password: None})
+                                  "pull": False, password: None})
 
 
 def test_user_args_passed_to_hint_user():


### PR DESCRIPTION
This PR will add the certificates to the proxy container, using the vault.  The vault process is described in https://github.com/reside-ic/proxy-nginx/pull/3

This also allows for a level of sub-configuration - here staging and production following much the same pattern as orderly-web-deploy, though the configuration is not persisted into the container at present.

Should ideally be merged after https://github.com/reside-ic/constellation/pull/3, with the .travis.yml updated to not point at the branch and install from pypi.

The staging instance is currently handled in https://github.com/mrc-ide/hint-deploy/pull/3 and these PRs interact but can be merged in any order