### PR TITLE
MRC-685: Flexible number of workers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
 
 script:
   # This line is required if using a branch of constellation:
-  - pip3 install git+https://github.com/reside-ic/constellation@reside-61#egg=constellation
+  # - pip3 install git+https://github.com/reside-ic/constellation@reside-61#egg=constellation
   - pip3 install -r requirements.txt
   - pytest --cov=src
   - pycodestyle .

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
 
 script:
   # This line is required if using a branch of constellation:
-  # - pip3 install git+https://github.com/reside-ic/constellation@reside-57#egg=constellation
+  - pip3 install git+https://github.com/reside-ic/constellation@reside-61#egg=constellation
   - pip3 install -r requirements.txt
   - pytest --cov=src
   - pycodestyle .

--- a/config/hint.yml
+++ b/config/hint.yml
@@ -12,6 +12,7 @@ hint:
 
 hintr:
   tag: "master"
+  workers: 2
 
 proxy:
   host: localhost

--- a/config/production.yml
+++ b/config/production.yml
@@ -1,3 +1,6 @@
+hintr:
+  workers: 5
+
 proxy:
   host: naomi.dide.ic.ac.uk
   port_http: 80

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-constellation==0.0.3
+constellation==0.0.4
 docopt
 pytest
 requests

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,4 +1,5 @@
 import docker
+import json
 import io
 import pytest
 import requests
@@ -54,6 +55,14 @@ def test_start_hint():
         hint_deploy.hint_user(cfg, "remove-user", user, False)
 
     assert f.getvalue() == "Removing user {}\nOK\n".format(user)
+
+    # Confirm we have brought up exactly two workers (none in the
+    # hintr container itself)
+    args = ["--silent", "http://hintr:8888/hintr/worker/status"]
+    logs = docker_util.return_logs_and_remove(
+        "byrnedo/alpine-curl:latest", args, network="hint_nw")
+    data = json.loads(logs)["data"]
+    assert len(data.keys()) == 2
 
     obj.destroy()
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -60,8 +60,8 @@ def test_start_hint():
     # hintr container itself)
     cl = docker.client.from_env()
     args = ["--silent", "http://hintr:8888/hintr/worker/status"]
-    result = client.containers.run("byrnedo/alpine-curl:latest", args,
-                                   network="hint_nw", stderr=True, remove=True)
+    result = cl.containers.run("byrnedo/alpine-curl:latest", args,
+                               network="hint_nw", stderr=True, remove=True)
     logs = result.decode("UTF-8")
     data = json.loads(logs)["data"]
     assert len(data.keys()) == 2

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -58,9 +58,11 @@ def test_start_hint():
 
     # Confirm we have brought up exactly two workers (none in the
     # hintr container itself)
+    cl = docker.client.from_env()
     args = ["--silent", "http://hintr:8888/hintr/worker/status"]
-    logs = docker_util.return_logs_and_remove(
-        "byrnedo/alpine-curl:latest", args, network="hint_nw")
+    result = client.containers.run("byrnedo/alpine-curl:latest", args,
+                                   network="hint_nw", stderr=True, remove=True)
+    logs = result.decode("UTF-8")
     data = json.loads(logs)["data"]
     assert len(data.keys()) == 2
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -30,6 +30,8 @@ def test_start_hint():
     assert docker_util.container_exists("hint_redis")
     assert docker_util.container_exists("hint_hintr")
     assert docker_util.container_exists("hint_hint")
+    assert docker_util.container_exists("hint_worker_1")
+    assert docker_util.container_exists("hint_worker_2")
 
     # Some basic user management
     user = "test@example.com"
@@ -62,6 +64,8 @@ def test_start_hint():
     assert not docker_util.container_exists("hint_redis")
     assert not docker_util.container_exists("hint_hintr")
     assert not docker_util.container_exists("hint_hint")
+    assert not docker_util.container_exists("hint_worker_1")
+    assert not docker_util.container_exists("hint_worker_2")
 
 
 def test_start_hint_from_cli():


### PR DESCRIPTION
This PR adds support for a scalable number of workers and updates the configurations accordingly. No workers are created in the hintr container, which runs now just a single process.

Depends on reside-61 / https://github.com/reside-ic/constellation/pull/4 - the tweak to the .travis.yml should be reverted before this is merged.