### PR TITLE
MRC-701: Use a shared volume for configuration

### DIFF
--- a/config/hint.yml
+++ b/config/hint.yml
@@ -7,7 +7,9 @@ db:
 
 hint:
   tag: "master"
-  volume: "hint_uploads"
+  volumes:
+    uploads: "hint_uploads"
+    config: "hint_config"
   expose: true
 
 hintr:

--- a/config/production.yml
+++ b/config/production.yml
@@ -1,3 +1,7 @@
+hint:
+  email:
+    password: VAULT:secret/hint/email:password
+
 proxy:
   host: naomi.dide.ic.ac.uk
   port_http: 80

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -29,6 +29,10 @@ class HintConfig:
         self.hintr_tag = config.config_string(dat, ["hintr", "tag"],
                                               True, default_tag)
 
+        self.hint_email_password = config.config_string(
+            dat, ["hint", "email", "password"], True, "")
+        self.hint_email_mode = "real" if self.hint_email_password else "disk"
+
         self.proxy_host = config.config_string(dat, ["proxy", "host"])
         self.proxy_port_http = config.config_integer(dat,
                                                      ["proxy", "port_http"],
@@ -140,8 +144,14 @@ def hint_configure(container, cfg):
     print("[hint] Configuring hint")
     config = {
         "application_url": "http://hint:8080",
-        "email_mode": "disk",
-        "email_password": "",
+        # drop (start)
+        "email_server": "smtp.cc.ic.ac.uk",
+        "email_port": 587,
+        "email_username": "naomi",
+        "email_sender": "naomi-notifications@imperial.ac.uk",
+        # drop (end)
+        "email_mode": cfg.hint_email_mode,
+        "email_password": cfg.hint_email_password,
         "upload_dir": "/uploads",
         "hintr_url": "http://hintr:8888",
         "db_url": "jdbc:postgresql://db/hint",

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -138,8 +138,15 @@ def db_configure(container, cfg):
 
 def hint_configure(container, cfg):
     print("[hint] Configuring hint")
-    config = {"hintr_url": "http://hintr:8888",
-              "upload_dir": "/uploads"}
+    config = {
+        "application_url": "http://hint:8080",
+        "email_mode": "disk",
+        "email_password": "",
+        "upload_dir": "/uploads",
+        "hintr_url": "http://hintr:8888",
+        "db_url": "jdbc:postgresql://db/hint",
+        "db_password": "changeme"
+    }
     config_str = "".join("{}={}\n".format(k, v) for k, v in config.items())
     docker_util.string_into_container(config_str, container,
                                       "/etc/hint/config.properties")

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,13 @@
+from src import hint_deploy
+
+
+def test_production_uses_real_email_configuration():
+    cfg = hint_deploy.HintConfig("config", "production")
+    assert cfg.hint_email_mode == "real"
+
+
+def test_base_and_staging_use_fake_email_configuration():
+    cfg = hint_deploy.HintConfig("config")
+    assert cfg.hint_email_mode == "disk"
+    cfg = hint_deploy.HintConfig("config", "staging")
+    assert cfg.hint_email_mode == "disk"


### PR DESCRIPTION
This PR uses a shared volume for configuration - mounted read-write into `hint` and read-only into the cli tool. The configuration is expanded to include enough to send an email, and the configuration has been updated for production to enable this (we might also want this on staging?)