### PR TITLE
MRC-685: Flexible number of workers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
 
 script:
   # This line is required if using a branch of constellation:
-  # - pip3 install git+https://github.com/reside-ic/constellation@reside-57#egg=constellation
+  # - pip3 install git+https://github.com/reside-ic/constellation@reside-61#egg=constellation
   - pip3 install -r requirements.txt
   - pytest --cov=src
   - pycodestyle .

--- a/config/hint.yml
+++ b/config/hint.yml
@@ -14,6 +14,7 @@ hint:
 
 hintr:
   tag: "master"
+  workers: 2
 
 proxy:
   host: localhost

--- a/config/production.yml
+++ b/config/production.yml
@@ -2,6 +2,9 @@ hint:
   email:
     password: VAULT:secret/hint/email:password
 
+hintr:
+  workers: 5
+
 proxy:
   host: naomi.dide.ic.ac.uk
   port_http: 80

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-constellation==0.0.3
+constellation==0.0.4
 docopt
 pytest
 requests

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -28,6 +28,7 @@ class HintConfig:
                                                  True, False)
         self.hintr_tag = config.config_string(dat, ["hintr", "tag"],
                                               True, default_tag)
+        self.hintr_workers = config.config_integer(dat, ["hintr", "workers"])
 
         self.hint_email_password = config.config_string(
             dat, ["hint", "email", "password"], True, "")
@@ -70,10 +71,10 @@ def hint_constellation(cfg):
                                              cfg.redis_tag)
     redis = constellation.ConstellationContainer("redis", redis_ref)
 
-    # 3. hintr (+ workers, for now)
+    # 3. hintr
     hintr_ref = constellation.ImageReference("mrcide", "hintr",
                                              cfg.hintr_tag)
-    hintr_args = ["--workers=2"]
+    hintr_args = ["--workers=0"]
     hintr_mounts = [constellation.ConstellationMount("uploads", "/uploads")]
     hintr_env = {"REDIS_URL": "redis://{}:6379".format(redis.name)}
     hintr = constellation.ConstellationContainer(
@@ -101,7 +102,14 @@ def hint_constellation(cfg):
         "proxy", proxy_ref, ports=proxy_ports, args=proxy_args,
         configure=proxy_configure)
 
-    containers = [db, redis, hintr, hint, proxy]
+    # 6. hintr workers
+    worker_ref = constellation.ImageReference("mrcide", "hintr-worker",
+                                              cfg.hintr_tag)
+    worker = constellation.ConstellationService(
+        "worker", worker_ref, cfg.hintr_workers,
+        mounts=hintr_mounts, environment=hintr_env)
+
+    containers = [db, redis, hintr, hint, proxy, worker]
 
     obj = constellation.Constellation("hint", cfg.prefix, containers,
                                       cfg.network, cfg.volumes,


### PR DESCRIPTION
This PR adds support for a scalable number of workers and updates the configurations accordingly. No workers are created in the hintr container, which runs now just a single process.

This PR replaces #7, which is failing on travis for unknown reasons.

Originally a squash commit, originally composed of:

* 9d1b81a Remove fetching source from github
* ed6705c Fix typo in test
* 0508b14 Try to fix travis
* 918c199 Add test of final worker state
* 3d58fb7 Additional tests
* 0a4485d Support for scalable workers