### PR TITLE
let staging send emails also

### DIFF
--- a/config/staging.yml
+++ b/config/staging.yml
@@ -10,3 +10,7 @@ vault:
   addr: https://vault.dide.ic.ac.uk:8200
   auth:
     method: github
+
+hint:
+  email:
+    password: VAULT:secret/hint/email:password

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,13 +1,13 @@
 from src import hint_deploy
 
 
-def test_production_uses_real_email_configuration():
+def test_production_and_staging_use_real_email_configuration():
     cfg = hint_deploy.HintConfig("config", "production")
+    assert cfg.hint_email_mode == "real"
+    cfg = hint_deploy.HintConfig("config", "staging")
     assert cfg.hint_email_mode == "real"
 
 
-def test_base_and_staging_use_fake_email_configuration():
+def test_base_uses_fake_email_configuration():
     cfg = hint_deploy.HintConfig("config")
-    assert cfg.hint_email_mode == "disk"
-    cfg = hint_deploy.HintConfig("config", "staging")
     assert cfg.hint_email_mode == "disk"


### PR DESCRIPTION
Coupled with https://github.com/mrc-ide/hint/pull/157 should allow us to start sending emails. Tbf we could test from prod, sending to our own email addresses, but might be nice to have it work on staging for testing.