### PR TITLE
mrc-710: Don't prompt for password

### DIFF
--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -1,5 +1,4 @@
 import docker
-import getpass
 import math
 import re
 import requests
@@ -123,8 +122,8 @@ def hint_user(cfg, action, email, pull, password=None):
     if pull or not docker_util.image_exists(str(ref)):
         docker_util.image_pull("hint cli", str(ref))
     args = [action, email]
-    if action == "add-user":
-        args.append(password or getpass.getpass())
+    if action == "add-user" and password:
+        args.append(password)
     client = docker.client.from_env()
     mounts = [docker.types.Mount("/etc/hint", cfg.volumes["config"],
                                  read_only=True)]

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -58,10 +58,12 @@ def test_start_hint():
 
     # Confirm we have brought up exactly two workers (none in the
     # hintr container itself)
-    cl = docker.client.from_env()
-    args = ["--silent", "http://hintr:8888/hintr/worker/status"]
-    result = cl.containers.run("byrnedo/alpine-curl:latest", args,
-                               network="hint_nw", stderr=True, remove=True)
+    script = 'message(httr::content(httr::GET(' + \
+             '"http://localhost:8888/hintr/worker/status"),' + \
+             '"text", encoding="UTF-8"))'
+    args = ["Rscript", "-e", script]
+    hintr = obj.containers.get("hintr", obj.prefix)
+    result = docker_util.exec_safely(hintr, args).output
     logs = result.decode("UTF-8")
     data = json.loads(logs)["data"]
     assert len(data.keys()) == 2


### PR DESCRIPTION
Now the cli can send emails if no password is provided, don't prompt for one.
