### PR TITLE
mrc-728: fix application url

### DIFF
--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -41,6 +41,8 @@ class HintConfig:
         self.proxy_port_https = config.config_integer(dat,
                                                       ["proxy", "port_https"],
                                                       True, 443)
+        self.proxy_url = proxy_url(self.proxy_host, self.proxy_port_https)
+
         self.proxy_ssl_certificate = config.config_string(
             dat, ["proxy", "ssl", "certificate"], True)
         self.proxy_ssl_key = config.config_string(
@@ -151,7 +153,7 @@ def db_configure(container, cfg):
 def hint_configure(container, cfg):
     print("[hint] Configuring hint")
     config = {
-        "application_url": "http://hint:8080",
+        "application_url": cfg.proxy_url,
         # drop (start)
         "email_server": "smtp.cc.ic.ac.uk",
         "email_port": 587,
@@ -198,3 +200,10 @@ def wait(f, message, timeout=30, poll=0.1):
             pass
         time.sleep(poll)
     raise Exception(message)
+
+
+def proxy_url(host, port):
+    if port == 443:
+        return "https://{}".format(host)
+    else:
+        return "https://{}:{}".format(host, port)

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -11,3 +11,10 @@ def test_production_and_staging_use_real_email_configuration():
 def test_base_uses_fake_email_configuration():
     cfg = hint_deploy.HintConfig("config")
     assert cfg.hint_email_mode == "disk"
+
+
+def test_proxy_url_drops_port_appropriately():
+    assert hint_deploy.proxy_url("example.com", 443) == \
+        "https://example.com"
+    assert hint_deploy.proxy_url("example.com", 1443) == \
+        "https://example.com:1443"

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -58,10 +58,12 @@ def test_start_hint():
 
     # Confirm we have brought up exactly two workers (none in the
     # hintr container itself)
-    cl = docker.client.from_env()
-    args = ["--silent", "http://hintr:8888/hintr/worker/status"]
-    result = cl.containers.run("byrnedo/alpine-curl:latest", args,
-                               network="hint_nw", stderr=True, remove=True)
+    script = 'message(httr::content(httr::GET(' + \
+             '"http://localhost:8888/hintr/worker/status"),' + \
+             '"text", encoding="UTF-8"))'
+    args = ["Rscript", "-e", script]
+    hintr = obj.containers.get("hintr", obj.prefix)
+    result = docker_util.exec_safely(hintr, args).output
     logs = result.decode("UTF-8")
     data = json.loads(logs)["data"]
     assert len(data.keys()) == 2


### PR DESCRIPTION
This PR sets the hint application url to be that of the proxy (the externally facing URL), scrubbing the port number where a standard https port is used.  I've tested this locally with the staging configuration and I get a sensible email back out