### PR TITLE
mrc-697: upgrade hintr and the whole app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
 
 script:
   # This line is required if using a branch of constellation:
-  - pip3 install git+https://github.com/reside-ic/constellation@reside-62#egg=constellation
+  # - pip3 install git+https://github.com/reside-ic/constellation@reside-62#egg=constellation
   - pip3 install -r requirements.txt
   - pytest --cov=src
   - pycodestyle .

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
 
 script:
   # This line is required if using a branch of constellation:
-  # - pip3 install git+https://github.com/reside-ic/constellation@reside-61#egg=constellation
+  - pip3 install git+https://github.com/reside-ic/constellation@reside-62#egg=constellation
   - pip3 install -r requirements.txt
   - pytest --cov=src
   - pycodestyle .

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Usage:
   ./hint stop  [--volumes] [--network] [--kill] [--force]
   ./hint destroy
   ./hint status
+  ./hint upgrade (hintr|all)
   ./hint user [--pull] add <email> [<password>]
   ./hint user [--pull] remove <email>
   ./hint user [--pull] exists <email>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-constellation==0.0.4
+constellation==0.0.5
 docopt
 pytest
 requests

--- a/src/hint_cli.py
+++ b/src/hint_cli.py
@@ -4,6 +4,7 @@ Usage:
   ./hint stop  [--volumes] [--network] [--kill] [--force]
   ./hint destroy
   ./hint status
+  ./hint upgrade (hintr|all) [<config>]
   ./hint user [--pull] add <email> [<password>]
   ./hint user [--pull] remove <email>
   ./hint user [--pull] exists <email>
@@ -21,7 +22,11 @@ import os.path
 import pickle
 import time
 
-from src.hint_deploy import HintConfig, hint_constellation, hint_user
+from src.hint_deploy import \
+    HintConfig, \
+    hint_constellation, \
+    hint_upgrade, \
+    hint_user
 
 
 def parse(argv=None):
@@ -45,6 +50,10 @@ def parse(argv=None):
     elif dat["status"]:
         action = "status"
         args = {}
+    elif dat["upgrade"]:
+        action = "upgrade"
+        config = dat["<config>"]
+        args = {"what": "hintr" if dat["hintr"] else "all"}
     elif dat["user"]:
         action = "user"
         if dat["add"]:
@@ -109,7 +118,10 @@ def main(argv=None):
         hint_user(cfg, **args)
     else:
         obj = hint_constellation(cfg)
-        obj.__getattribute__(action)(**args)
+        if action == "upgrade":
+            hint_upgrade(cfg, obj, args["what"])
+        else:
+            obj.__getattribute__(action)(**args)
         if action == "start" and cfg.add_test_user:
             email = "test.user@example.com"
             pull = args["pull_images"]

--- a/src/hint_cli.py
+++ b/src/hint_cli.py
@@ -119,7 +119,7 @@ def main(argv=None):
     else:
         obj = hint_constellation(cfg)
         if action == "upgrade":
-            hint_upgrade(cfg, obj, args["what"])
+            hint_upgrade(obj, args["what"])
         else:
             obj.__getattribute__(action)(**args)
         if action == "start" and cfg.add_test_user:

--- a/src/hint_cli.py
+++ b/src/hint_cli.py
@@ -4,7 +4,7 @@ Usage:
   ./hint stop  [--volumes] [--network] [--kill] [--force]
   ./hint destroy
   ./hint status
-  ./hint upgrade (hintr|all) [<config>]
+  ./hint upgrade (hintr|all)
   ./hint user [--pull] add <email> [<password>]
   ./hint user [--pull] remove <email>
   ./hint user [--pull] exists <email>
@@ -52,7 +52,6 @@ def parse(argv=None):
         args = {}
     elif dat["upgrade"]:
         action = "upgrade"
-        config = dat["<config>"]
         args = {"what": "hintr" if dat["hintr"] else "all"}
     elif dat["user"]:
         action = "user"

--- a/src/hint_cli.py
+++ b/src/hint_cli.py
@@ -26,7 +26,7 @@ import timeago
 from src.hint_deploy import \
     HintConfig, \
     hint_constellation, \
-    hint_upgrade, \
+    hint_upgrade_hintr, \
     hint_user
 
 
@@ -52,8 +52,12 @@ def parse(argv=None):
         action = "status"
         args = {}
     elif dat["upgrade"]:
-        action = "upgrade"
-        args = {"what": "hintr" if dat["hintr"] else "all"}
+        if dat["hintr"]:
+            action = "upgrade_hintr"
+            args = {}
+        else:
+            action = "restart"
+            args = {"pull_images": True}
     elif dat["user"]:
         action = "user"
         if dat["add"]:
@@ -131,14 +135,12 @@ def main(argv=None):
     cfg = load_config(path, config_name)
     if action == "user":
         hint_user(cfg, **args)
+    elif action == "upgrade_hintr":
+        hint_upgrade_hintr(hint_constellation(cfg))
     else:
         obj = hint_constellation(cfg)
         verify_data_loss(action, args, cfg)
-
-        if action == "upgrade":
-            hint_upgrade(obj, args["what"])
-        else:
-            obj.__getattribute__(action)(**args)
+        obj.__getattribute__(action)(**args)
 
         if action == "start" and cfg.add_test_user:
             email = "test.user@example.com"

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -155,8 +155,6 @@ def hint_upgrade_hintr(obj):
             container.exec_run(["hintr_stop"])
         docker_util.container_remove_wait(container)
 
-    worker.remove(obj.prefix)
-
     obj.start(subset=[hintr.name, worker.name])
 
 

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -130,13 +130,7 @@ def hint_upgrade(obj, what):
     if what == "hintr":
         hint_upgrade_hintr(obj)
     else:
-        hint_upgrade_all(obj)
-
-
-def hint_upgrade_all(obj):
-    obj.containers.pull_images()
-    obj.stop()
-    obj.start()
+        obj.restart(pull_images=True)
 
 
 def hint_upgrade_hintr(obj):

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -123,25 +123,23 @@ def hint_constellation(cfg):
     return obj
 
 
-def hint_upgrade(cfg, obj, what):
+def hint_upgrade(obj, what):
     if what == "hintr":
-        hint_upgrade_hintr(cfg, obj)
+        hint_upgrade_hintr(obj)
     else:
-        hint_upgrade_all(cfg, obj)
+        hint_upgrade_all(obj)
 
 
-def hint_upgrade_all(cfg, obj):
-    raise Exception("Not yet implemented")
+def hint_upgrade_all(obj):
+    obj.containers.pull_images()
+    obj.stop()
+    obj.start()
 
 
-def hint_upgrade_hintr(cfg, obj):
+def hint_upgrade_hintr(obj):
     hintr = obj.containers.find("hintr")
     worker = obj.containers.find("worker")
-    container = hintr.get(cfg.prefix)
-
-    # We'll do this via pickle/load of the configuration
-    # if cfg.hintr_workers != len(worker.get(cfg.prefix)):
-    #     raise Exception("Configuration mismatch - wrong number of workers")
+    container = hintr.get(obj.prefix)
 
     # Always pull the docker image - and do this *before* we start
     # removing things to minimise downtime.
@@ -153,7 +151,7 @@ def hint_upgrade_hintr(cfg, obj):
             container.exec_run(["hintr_stop"])
         docker_util.container_remove_wait(container)
 
-    worker.remove(cfg.prefix)
+    worker.remove(obj.prefix)
 
     obj.start(subset=[hintr.name, worker.name])
 

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -129,13 +129,6 @@ def hint_constellation(cfg):
     return obj
 
 
-def hint_upgrade(obj, what):
-    if what == "hintr":
-        hint_upgrade_hintr(obj)
-    else:
-        obj.restart(pull_images=True)
-
-
 def hint_upgrade_hintr(obj):
     hintr = obj.containers.find("hintr")
     worker = obj.containers.find("worker")

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -43,6 +43,11 @@ def test_cli_parse():
         ("config", None, "user", {"email": email, "action": "remove-user",
                                   "pull": False, password: None})
 
+    assert hint_cli.parse(["upgrade", "hintr"]) == \
+        ("config", None, "upgrade", {"what": "hintr"})
+    assert hint_cli.parse(["upgrade", "all"]) == \
+        ("config", None, "upgrade", {"what": "all"})
+
 
 def test_user_args_passed_to_hint_user():
     email = "user@example.com"

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -47,9 +47,9 @@ def test_cli_parse():
                                   "pull": False, password: None})
 
     assert hint_cli.parse(["upgrade", "hintr"]) == \
-        ("config", None, "upgrade", {"what": "hintr"})
+        ("config", None, "upgrade_hintr", {})
     assert hint_cli.parse(["upgrade", "all"]) == \
-        ("config", None, "upgrade", {"what": "all"})
+        ("config", None, "restart", {"pull_images": True})
 
 
 def test_user_args_passed_to_hint_user():

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -139,6 +139,7 @@ def test_update_hintr_and_all():
     assert docker_util.container_exists("hint_hintr")
     assert docker_util.container_exists("hint_hint")
     assert len(docker_util.containers_matching("hint_worker_", False)) == 2
+    assert len(docker_util.containers_matching("hint_worker_", True)) == 4
 
     f = io.StringIO()
     with redirect_stdout(f):
@@ -158,3 +159,7 @@ def test_update_hintr_and_all():
     assert docker_util.container_exists("hint_hintr")
     assert docker_util.container_exists("hint_hint")
     assert len(docker_util.containers_matching("hint_worker_", False)) == 2
+
+    cfg = hint_deploy.HintConfig("config")
+    obj = hint_deploy.hint_constellation(cfg)
+    obj.destroy()

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -145,7 +145,7 @@ def test_update_hintr_and_all():
     p = f.getvalue()
     assert "Pulling docker image db" in p
     assert "Stop 'redis'" in p
-    assert "Removing 'redis'"  in p
+    assert "Removing 'redis'" in p
     assert "Starting redis" in p
 
     assert docker_util.network_exists("hint_nw")

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -32,8 +32,7 @@ def test_start_hint():
     assert docker_util.container_exists("hint_redis")
     assert docker_util.container_exists("hint_hintr")
     assert docker_util.container_exists("hint_hint")
-    assert docker_util.container_exists("hint_worker_1")
-    assert docker_util.container_exists("hint_worker_2")
+    assert len(docker_util.containers_matching("hint_worker_", False)) == 2
 
     # Some basic user management
     user = "test@example.com"
@@ -78,8 +77,7 @@ def test_start_hint():
     assert not docker_util.container_exists("hint_redis")
     assert not docker_util.container_exists("hint_hintr")
     assert not docker_util.container_exists("hint_hint")
-    assert not docker_util.container_exists("hint_worker_1")
-    assert not docker_util.container_exists("hint_worker_2")
+    assert len(docker_util.containers_matching("hint_worker_", False)) == 0
 
 
 def test_start_hint_from_cli():

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -114,3 +114,44 @@ def test_configure_proxy():
     assert docker_util.string_from_container(
         container, "/run/proxy/key.pem") == key
     container.kill()
+
+
+def test_update_hintr_and_all():
+    hint_cli.main(["start"])
+
+    f = io.StringIO()
+    with redirect_stdout(f):
+        hint_cli.main(["upgrade", "hintr"])
+
+    p = f.getvalue()
+    assert "Pulling docker image hintr" in p
+    assert "Stopping previous hintr and workers" in p
+    assert "Starting hintr" in p
+    assert "Starting *service* worker" in p
+
+    assert docker_util.network_exists("hint_nw")
+    assert docker_util.volume_exists("hint_db_data")
+    assert docker_util.volume_exists("hint_uploads")
+    assert docker_util.container_exists("hint_db")
+    assert docker_util.container_exists("hint_redis")
+    assert docker_util.container_exists("hint_hintr")
+    assert docker_util.container_exists("hint_hint")
+    assert len(docker_util.containers_matching("hint_worker_", False)) == 2
+
+    f = io.StringIO()
+    with redirect_stdout(f):
+        hint_cli.main(["upgrade", "all"])
+
+    p = f.getvalue()
+    assert "Pulling docker image db" in p
+    assert "Removing 'redis'" in p
+    assert "Starting hintr" redis p
+
+    assert docker_util.network_exists("hint_nw")
+    assert docker_util.volume_exists("hint_db_data")
+    assert docker_util.volume_exists("hint_uploads")
+    assert docker_util.container_exists("hint_db")
+    assert docker_util.container_exists("hint_redis")
+    assert docker_util.container_exists("hint_hintr")
+    assert docker_util.container_exists("hint_hint")
+    assert len(docker_util.containers_matching("hint_worker_", False)) == 2

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -144,8 +144,9 @@ def test_update_hintr_and_all():
 
     p = f.getvalue()
     assert "Pulling docker image db" in p
-    assert "Removing 'redis'" in p
-    assert "Starting hintr" redis p
+    assert "Stop 'redis'" in p
+    assert "Removing 'redis'"  in p
+    assert "Starting redis" in p
 
     assert docker_util.network_exists("hint_nw")
     assert docker_util.volume_exists("hint_db_data")


### PR DESCRIPTION
This PR will allow fairly graceful upgrades of hintr, or of all containers.

For hintr upgrade we

1. pull a new hintr image
2. tell workers to stop once they've finished any jobs
3. stop the hintr server
4. bring up the new hintr server
5. bring up new workers

This will leave current sessions unaffected, and current running jobs will continue.  There will be a period of hintr outage, hopefully < 3 s

For the full upgrade we are less graceful and simply

1. pull all images
2. stop all containers (gracefully, slower than kill)
3. start the whole thing again

This will close all client connections and require re-login.

I am not sure if we should call this "upgrade" or "update". Thoughts?

This PR depends on #14 and https://github.com/reside-ic/constellation/pull/5 and the `.travis.yml` should be updated after the constellation PR is merged.