### PR TITLE
mrc-730: create key directory before hint startup

### DIFF
--- a/config/hint.yml
+++ b/config/hint.yml
@@ -6,7 +6,7 @@ db:
   volume: "hint_db_data"
 
 hint:
-  tag: "mrc-729"
+  tag: "master"
   volumes:
     uploads: "hint_uploads"
     config: "hint_config"

--- a/config/hint.yml
+++ b/config/hint.yml
@@ -6,7 +6,7 @@ db:
   volume: "hint_db_data"
 
 hint:
-  tag: "master"
+  tag: "mrc-729"
   volumes:
     uploads: "hint_uploads"
     config: "hint_config"

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -155,6 +155,7 @@ def db_configure(container, cfg):
 
 def hint_configure(container, cfg):
     print("[hint] Configuring hint")
+    docker_util.exec_safely(container, ["mkdir", "-p", "/etc/hint/token_key"])
     config = {
         "application_url": cfg.proxy_url,
         # drop (start)


### PR DESCRIPTION
This enables the key persistence in https://github.com/mrc-ide/hint/pull/165