### PR TITLE
mrc-742: Protect from data loss

### DIFF
--- a/config/production.yml
+++ b/config/production.yml
@@ -20,3 +20,6 @@ vault:
 
 users:
   add_test_user: false
+
+deploy:
+  protect_data: true

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -60,6 +60,9 @@ class HintConfig:
         self.add_test_user = config.config_boolean(
             dat, ["users", "add_test_user"], True, False)
 
+        self.protect_data = config.config_boolean(
+            dat, ["deploy", "protect_data"], True, False)
+
 
 def hint_constellation(cfg):
     # 1. The db

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,5 +1,8 @@
+import io
 import pytest
+import string
 
+from contextlib import redirect_stdout
 from unittest import mock
 
 from src import hint_cli
@@ -61,3 +64,53 @@ def test_other_args_passed_to_start():
         hint_cli.main(["status"])
 
     assert obj.status.called
+
+
+def test_verify_data_loss_silent_if_no_loss():
+    cfg = hint_deploy.HintConfig("config")
+    f = io.StringIO()
+    with redirect_stdout(f):
+        with mock.patch('src.hint_cli.prompt_yes_no') as prompt:
+            prompt.return_value = True
+            hint_cli.verify_data_loss("start", {}, cfg)
+            hint_cli.verify_data_loss("stop", {"remove_volumes": False}, cfg)
+
+    assert not prompt.called
+    assert f.getvalue() == ""
+
+
+def test_verify_data_loss_warns_if_loss():
+    cfg = hint_deploy.HintConfig("config")
+    f = io.StringIO()
+    with redirect_stdout(f):
+        with mock.patch('src.hint_cli.prompt_yes_no') as prompt:
+            prompt.return_value = True
+            hint_cli.verify_data_loss("stop", {"remove_volumes": True}, cfg)
+
+    assert prompt.called
+    assert "WARNING! PROBABLE IRREVERSIBLE DATA LOSS!" in f.getvalue()
+
+
+def test_verify_data_loss_throws_if_loss():
+    cfg = hint_deploy.HintConfig("config")
+    with mock.patch('src.hint_cli.prompt_yes_no') as prompt:
+        prompt.return_value = False
+        with pytest.raises(Exception, match="Not continuing"):
+            hint_cli.verify_data_loss("stop", {"remove_volumes": True}, cfg)
+
+
+def test_verify_data_prevents_unwanted_loss():
+    cfg = hint_deploy.HintConfig("config")
+    cfg.protect_data = True
+    msg = "Cannot remove volumes with this configuration"
+    with mock.patch('src.hint_cli.prompt_yes_no') as prompt:
+        with pytest.raises(Exception, match=msg):
+            hint_cli.verify_data_loss("stop", {"remove_volumes": True}, cfg)
+
+
+def test_prompt_is_quite_strict():
+    assert hint_cli.prompt_yes_no(lambda x: "yes")
+    assert not hint_cli.prompt_yes_no(lambda x: "no")
+    assert not hint_cli.prompt_yes_no(lambda x: "Yes")
+    assert not hint_cli.prompt_yes_no(lambda x: "Great idea!")
+    assert not hint_cli.prompt_yes_no(lambda x: "")

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -7,6 +7,7 @@ import requests
 import time
 
 from contextlib import redirect_stdout
+from unittest import mock
 
 import constellation
 import constellation.docker_util as docker_util
@@ -92,7 +93,9 @@ def test_start_hint_from_cli():
     assert os.path.exists("config/.last_deploy")
     hint_cli.main(["stop"])
     assert os.path.exists("config/.last_deploy")
-    hint_cli.main(["destroy"])
+    with mock.patch('src.hint_cli.prompt_yes_no') as prompt:
+        prompt.return_value = True
+        hint_cli.main(["destroy"])
     assert not os.path.exists("config/.last_deploy")
 
 


### PR DESCRIPTION
This PR will protect against unwanted data loss when using the deploy tool, as discussed in the kitchen on Wednesday

The only real way we lose data is if the volumes are removed.  That happens with `./hint stop --volumes` and `hint --destroy`, which is basically just a wrapper around `./hint stop --volumes --networks --kill`.

When we're running in most environments, including testing situations, we will prompt the user and explain what the consequences are.

When we're running in production we should not lose data ever, so it is just flat out refused. Rather than switch on the configuration name, this is based off of the configuration option `deploy: protect_data: <bool>`, which is enabled in production.yml
