### PR TITLE
mrc-783: don't error if adding users that already exist

### DIFF
--- a/src/hint_cli.py
+++ b/src/hint_cli.py
@@ -127,7 +127,7 @@ keypairs used to sign login requests, etc.""")
 
 
 def prompt_yes_no(get_input=input):
-    return get_input("Continue? [yes/no] ") == "yes"
+    return get_input("\nContinue? [yes/no] ") == "yes"
 
 
 def main(argv=None):

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -53,6 +53,13 @@ def test_start_hint():
 
     f = io.StringIO()
     with redirect_stdout(f):
+        hint_deploy.hint_user(cfg, "add-user", user, True, "password")
+
+    p = f.getvalue()
+    assert "Not adding user {} as they already exist".format(user) in p
+
+    f = io.StringIO()
+    with redirect_stdout(f):
         hint_deploy.hint_user(cfg, "remove-user", user, False)
 
     assert f.getvalue() == "Removing user {}\nOK\n".format(user)


### PR DESCRIPTION
This PR will skip adding users that already exist. This is needed to start a hint constellation with a test user for a second time.