### PR TITLE
MRC-789: Use unaids domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,26 @@ The bandwidth and latency of the connection will be affected - see `./scripts/sl
 
 ## Proxy & SSL
 
-For now, we're going to use self-signed certificates for `naomi.dide.ic.ac.uk`, which we will replace with more reasonable certificates later.  Certificates are generated during start-up of the proxy container.
+There are 3 options for ssl certificates
+
+1. Self-signed certificates, which are generated in the proxy at startup (this is the default configuration option)
+2. Certificates for `naomi.dide.ic.ac.uk`, provided by ICT (see [details on `reside-ic/proxy-nginx`](https://github.com/reside-ic/proxy-nginx#getting-a-certificate-from-ict)), stored in the mrc-ide vault
+3. Certificates from UNAIDS
+
+For the last option, UNAIDS will send a certificate.  Instructions are [on the leaderssl website](https://www.leaderssl.com/articles/131-certificate-installation-nginx)
+
+```
+cat naomi_unaids_org.crt  naomi_unaids_org.ca-bundle > ssl-bundle.crt
+```
+
+```
+export VAULT_ADDR=https://vault.dide.ic.ac.uk:8200
+vault login -method=github
+vault write /secret/hint/ssl/unaids certificate=@ssl-bundle.crt key=@naomi.key
+```
+
+we're going to use self-signed certificates for `naomi.dide.ic.ac.uk`, which we will replace with more reasonable certificates later.  Certificates are generated during start-up of the proxy container.
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,13 @@ There are 3 options for ssl certificates
 
 For the last option, UNAIDS will send a certificate.  Instructions are [on the leaderssl website](https://www.leaderssl.com/articles/131-certificate-installation-nginx)
 
+First, concatenate the certificates:
+
 ```
 cat naomi_unaids_org.crt  naomi_unaids_org.ca-bundle > ssl-bundle.crt
 ```
+
+Then add them to the [mrc-ide vault](https://github.com/mrc-ide/vault):
 
 ```
 export VAULT_ADDR=https://vault.dide.ic.ac.uk:8200
@@ -71,8 +75,7 @@ vault login -method=github
 vault write /secret/hint/ssl/unaids certificate=@ssl-bundle.crt key=@naomi.key
 ```
 
-we're going to use self-signed certificates for `naomi.dide.ic.ac.uk`, which we will replace with more reasonable certificates later.  Certificates are generated during start-up of the proxy container.
-
+The production configuration will read these in.
 
 ## License
 

--- a/config/production.yml
+++ b/config/production.yml
@@ -6,12 +6,12 @@ hintr:
   workers: 5
 
 proxy:
-  host: naomi.dide.ic.ac.uk
+  host: naomi.unaids.org
   port_http: 80
   port_https: 443
   ssl:
-    certificate: VAULT:secret/hint/ssl/naomi:certificate
-    key: VAULT:secret/hint/ssl/naomi:key
+    certificate: VAULT:secret/hint/ssl/unaids:certificate
+    key: VAULT:secret/hint/ssl/unaids:key
 
 vault:
   addr: https://vault.dide.ic.ac.uk:8200


### PR DESCRIPTION
This PR updates the configuration to use the unaids address rather than our in-house address for production.

Instructions added, based on what I just did