### PR TITLE
mrc-799: don't lose container configuration name after container loss

### DIFF
--- a/src/hint_cli.py
+++ b/src/hint_cli.py
@@ -96,11 +96,12 @@ def load_config(path, config_name=None):
         dat = read_config(path)
         when = timeago.format(dat["time"])
         cfg = HintConfig(path, dat["config_name"])
+        config_name = dat["config_name"]
         print("[Loaded configuration '{}' ({})]".format(
-            dat["config_name"] or "<base>", when))
+            config_name or "<base>", when))
     else:
         cfg = HintConfig(path, config_name)
-    return cfg
+    return config_name, cfg
 
 
 def remove_config(path):
@@ -132,7 +133,7 @@ def prompt_yes_no(get_input=input):
 
 def main(argv=None):
     path, config_name, action, args = parse(argv)
-    cfg = load_config(path, config_name)
+    config_name, cfg = load_config(path, config_name)
     if action == "user":
         hint_user(cfg, **args)
     elif action == "upgrade_hintr":

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -26,5 +26,10 @@ def test_load_and_reload_config():
     cfg = hint_deploy.HintConfig(path, config)
     cfg.hint_tag = "develop"
     hint_cli.save_config(path, config, cfg)
-    assert hint_cli.load_config(path, None).hint_tag == "master"
+
+    hint_cli.read_config(path)
+
+    config_name, config_value = hint_cli.load_config(path, None)
+    assert config_value.hint_tag == "master"
+    assert config_name == "production"
     hint_cli.remove_config(path)

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -95,7 +95,7 @@ def test_start_hint_from_cli():
     # Need a dummy extra configuration file that does not trigger the
     # vault
     with open("config/other.yml", "w") as f:
-        f.write("proxy:\n host: localhost");
+        f.write("proxy:\n host: localhost")
 
     hint_cli.main(["start", "other"])
     res = requests.get("http://localhost:8080")

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -91,17 +91,30 @@ def test_start_hint():
 def test_start_hint_from_cli():
     if os.path.exists("config/.last_deploy"):
         os.remove("config/.last_deploy")
-    hint_cli.main(["start"])
+
+    # Need a dummy extra configuration file that does not trigger the
+    # vault
+    with open("config/other.yml", "w") as f:
+        f.write("proxy:\n host: localhost");
+
+    hint_cli.main(["start", "other"])
     res = requests.get("http://localhost:8080")
     assert res.status_code == 200
     assert "Login" in res.content.decode("UTF-8")
     assert os.path.exists("config/.last_deploy")
-    hint_cli.main(["stop"])
+    assert hint_cli.read_config("config")["config_name"] == "other"
+    hint_cli.main(["stop", "--kill"])
     assert os.path.exists("config/.last_deploy")
+    assert hint_cli.read_config("config")["config_name"] == "other"
+    hint_cli.main(["start"])
+    assert os.path.exists("config/.last_deploy")
+    assert hint_cli.read_config("config")["config_name"] == "other"
+
     with mock.patch('src.hint_cli.prompt_yes_no') as prompt:
         prompt.return_value = True
         hint_cli.main(["destroy"])
     assert not os.path.exists("config/.last_deploy")
+    os.remove("config/other.yml")
 
 
 # this checks that specifying the ssl certificates in the


### PR DESCRIPTION
Previously if containers went down and the system was started up again with `./hint-deploy start` the configuration name was lost. This PR repairs that.  The modifications to the integration test replicate the previous scenario that lead to the loss of the configuration name.