### PR TITLE
mrc-1146: Resolve secrets before hintr upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
 
 script:
   # This line is required if using a branch of constellation:
-  # - pip3 install git+https://github.com/reside-ic/constellation@reside-62#egg=constellation
+  - pip3 install git+https://github.com/reside-ic/constellation@reside-83#egg=constellation
   - pip3 install -r requirements.txt
   - pytest --cov=src
   - pycodestyle .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-constellation==0.0.5
+constellation==0.0.6
 docopt
 pytest
 requests

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -141,6 +141,7 @@ def hint_upgrade_hintr(obj):
     hintr = obj.containers.find("hintr")
     worker = obj.containers.find("worker")
     container = hintr.get(obj.prefix)
+    obj.resolve_secrets()
 
     # Always pull the docker image - and do this *before* we start
     # removing things to minimise downtime.


### PR DESCRIPTION
This will cause the prompt for a github token to happen earlier during upgrades.

After https://github.com/reside-ic/constellation/pull/6 is merged and pushed to pypi, the version pin on reside-83 should be removed.