### PR TITLE
mrc-1308: Expose hintr port to the network

### DIFF
--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -97,9 +97,10 @@ def hint_constellation(cfg):
     hintr_env = {"REDIS_URL": "redis://{}:6379".format(redis.name)}
     if cfg.hintr_use_mock_model:
         hintr_env["USE_MOCK_MODEL"] = "true"
+    hintr_ports = [8888] if cfg.hint_expose else None
     hintr = constellation.ConstellationContainer(
         "hintr", hintr_ref, args=hintr_args, mounts=hintr_mounts,
-        environment=hintr_env)
+        ports=hintr_ports, environment=hintr_env)
 
     # 4. hint
     hint_ref = constellation.ImageReference("mrcide", "hint",

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -26,6 +26,10 @@ def test_start_hint():
     assert res.status_code == 200
     assert "Login" in res.content.decode("UTF-8")
 
+    res = requests.get("http://localhost:8888")
+
+    assert res.status_code == 200
+
     assert docker_util.network_exists("hint_nw")
     assert docker_util.volume_exists("hint_db_data")
     assert docker_util.volume_exists("hint_uploads")


### PR DESCRIPTION
As discussed on slack, this will expose the hintr server to the network (practically this is on the VPN) so that we can implement the debug endpoint.