### PR TITLE
mrc-1316: persistent redis

### DIFF
--- a/config/hint.yml
+++ b/config/hint.yml
@@ -1,5 +1,6 @@
 redis:
   tag: "5.0"
+  volume: "hint_redis_data"
 
 db:
   tag: master

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -56,6 +56,8 @@ class HintConfig:
         self.volumes = {
             "db": config.config_string(
                 dat, ["db", "volume"]),
+            "redis": config.config_string(
+                dat, ["redis", "volume"]),
             "uploads": config.config_string(
                 dat, ["hint", "volumes", "uploads"]),
             "config": config.config_string(
@@ -84,7 +86,10 @@ def hint_constellation(cfg):
     # 2. Redis
     redis_ref = constellation.ImageReference("library", "redis",
                                              cfg.redis_tag)
-    redis = constellation.ConstellationContainer("redis", redis_ref)
+    redis_mounts = [constellation.ConstellationMount("redis", "/data")]
+    redis_args = ["--appendonly", "yes"]
+    redis = constellation.ConstellationContainer(
+        "redis", redis_ref, mounts=redis_mounts, args=redis_args)
 
     # 3. hintr
     hintr_ref = cfg.hintr_ref

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -174,8 +174,8 @@ def test_update_hintr_and_all():
     assert len(docker_util.containers_matching("hint_worker_", False)) == 2
     assert len(docker_util.containers_matching("hint_worker_", True)) == 4
 
-    ## We are going to write some data into redis here and later check
-    ## that it survived the upgrade.
+    # We are going to write some data into redis here and later check
+    # that it survived the upgrade.
     cfg = hint_deploy.HintConfig("config")
     obj = hint_deploy.hint_constellation(cfg)
     args_set = ["redis-cli", "SET", "data_persists", "yes"]

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -174,6 +174,14 @@ def test_update_hintr_and_all():
     assert len(docker_util.containers_matching("hint_worker_", False)) == 2
     assert len(docker_util.containers_matching("hint_worker_", True)) == 4
 
+    ## We are going to write some data into redis here and later check
+    ## that it survived the upgrade.
+    cfg = hint_deploy.HintConfig("config")
+    obj = hint_deploy.hint_constellation(cfg)
+    args_set = ["redis-cli", "SET", "data_persists", "yes"]
+    redis = obj.containers.get("redis", obj.prefix)
+    docker_util.exec_safely(redis, args_set)
+
     f = io.StringIO()
     with redirect_stdout(f):
         hint_cli.main(["upgrade", "all"])
@@ -195,6 +203,8 @@ def test_update_hintr_and_all():
     assert docker_util.container_exists("hint_hint")
     assert len(docker_util.containers_matching("hint_worker_", False)) == 2
 
-    cfg = hint_deploy.HintConfig("config")
-    obj = hint_deploy.hint_constellation(cfg)
+    redis = obj.containers.get("redis", obj.prefix)
+    result = docker_util.exec_safely(redis, args_get).output.decode("UTF-8")
+    assert "yes" in result
+
     obj.destroy()

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -204,6 +204,7 @@ def test_update_hintr_and_all():
     assert len(docker_util.containers_matching("hint_worker_", False)) == 2
 
     redis = obj.containers.get("redis", obj.prefix)
+    args_get = ["redis-cli", "GET", "data_persists"]
     result = docker_util.exec_safely(redis, args_get).output.decode("UTF-8")
     assert "yes" in result
 


### PR DESCRIPTION
The actual commands for deploying are more complex than usual:

```
docker cp hint_redis:/data/dump.rdb .
docker volume create hint_redis_data
docker run --rm -v $PWD:/incoming -v hint_redis_data:/data alpine \
  cp /incoming/dump.rdb /data/dump.rdb
docker run -d --rm --name redis_restore -v hint_redis_data:/data \
  redis:latest
docker exec redis_restore redis-cli BGREWRITEAOF
docker logs -f redis_restore # wait here until write finishes
docker stop redis_restore
docker run -d --rm --name redis_restore -v hint_redis_data:/data \
  redis:latest --appendonly yes
docker exec -it redis_restore redis-cli SMEMBERS hintr:worker:name
```

Then upgrade.