### PR TITLE
Remove extra https:// from URL

### DIFF
--- a/config/production.yml
+++ b/config/production.yml
@@ -1,5 +1,5 @@
 hint:
-  adr_url: https://https://adr.unaids.org/
+  adr_url: https://adr.unaids.org/
   email:
     password: VAULT:secret/hint/email:password
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -3,7 +3,7 @@ from src import hint_cli, hint_deploy
 
 def test_production_uses_real_adr():
     cfg = hint_deploy.HintConfig("config", "production")
-    assert cfg.hint_adr_url == "https://https://adr.unaids.org/"
+    assert cfg.hint_adr_url == "https://adr.unaids.org/"
 
 
 def test_real_adr_optional():


### PR DESCRIPTION
I think this was in unintentionally?

Noticed some errors in the logs on production which I am guessing is related to this
```
[http-nio-8080-exec-3] ERROR org.imperial.mrc.hint.logging.ErrorLoggingFilter - ERROR: 500 response for /adr/datasets/
[http-nio-8080-exec-3] ERROR org.imperial.mrc.hint.logging.ErrorLoggingFilter - {"data":{},"status":"failure","errors":[{"detail":"No response returned. The request may have timed out.","error":"OTHER_ERROR"}]}

```