### PR TITLE
Start a calibrate only worker during deploy

### DIFF
--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -130,13 +130,19 @@ def hint_constellation(cfg):
         "proxy", proxy_ref, ports=proxy_ports, args=proxy_args,
         configure=proxy_configure)
 
-    # 6. hintr workers
+    # 6. calibrate worker
     worker_ref = cfg.hintr_worker_ref
+    calibrate_worker_args = ["--calibrate-only"]
+    calibrate_worker = constellation.ConstellationContainer(
+        "worker_calibrate", worker_ref, args = calibrate_worker_args,
+        mounts=hintr_mounts, environment=hintr_env)
+
+    # 7. hintr workers
     worker = constellation.ConstellationService(
         "worker", worker_ref, cfg.hintr_workers,
         mounts=hintr_mounts, environment=hintr_env)
 
-    containers = [db, redis, hintr, hint, proxy, worker]
+    containers = [db, redis, hintr, hint, proxy, calibrate_worker, worker]
 
     obj = constellation.Constellation("hint", cfg.prefix, containers,
                                       cfg.network, cfg.volumes,

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -134,7 +134,7 @@ def hint_constellation(cfg):
     worker_ref = cfg.hintr_worker_ref
     calibrate_worker_args = ["--calibrate-only"]
     calibrate_worker = constellation.ConstellationContainer(
-        "worker_calibrate", worker_ref, args = calibrate_worker_args,
+        "worker_calibrate", worker_ref, args=calibrate_worker_args,
         mounts=hintr_mounts, environment=hintr_env)
 
     # 7. hintr workers

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -39,7 +39,8 @@ def test_start_hint():
     assert docker_util.container_exists("hint_redis")
     assert docker_util.container_exists("hint_hintr")
     assert docker_util.container_exists("hint_hint")
-    assert len(docker_util.containers_matching("hint_worker_", False)) == 2
+    assert docker_util.container_exists("hint_worker_calibrate")
+    assert len(docker_util.containers_matching("hint_worker_", False)) == 3
 
     # Some basic user management
     user = "test@example.com"

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -94,6 +94,7 @@ def test_start_hint():
     assert not docker_util.container_exists("hint_redis")
     assert not docker_util.container_exists("hint_hintr")
     assert not docker_util.container_exists("hint_hint")
+    assert not docker_util.container_exists("hint_worker_calibrate")
     assert len(docker_util.containers_matching("hint_worker_", False)) == 0
 
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -81,7 +81,7 @@ def test_start_hint():
     result = docker_util.exec_safely(hintr, args).output
     logs = result.decode("UTF-8")
     data = json.loads(logs)["data"]
-    assert len(data.keys()) == 2
+    assert len(data.keys()) == 3
 
     obj.destroy()
 
@@ -175,7 +175,7 @@ def test_update_hintr_and_all():
     assert docker_util.container_exists("hint_hintr")
     assert docker_util.container_exists("hint_hint")
     assert docker_util.container_exists("hint_worker_calibrate")
-    assert len(docker_util.containers_matching("hint_worker_", False)) == 3
+    assert len(docker_util.containers_matching("hint_worker_", False)) == 2
     assert len(docker_util.containers_matching("hint_worker_", True)) == 5
 
     # We are going to write some data into redis here and later check

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -174,8 +174,9 @@ def test_update_hintr_and_all():
     assert docker_util.container_exists("hint_redis")
     assert docker_util.container_exists("hint_hintr")
     assert docker_util.container_exists("hint_hint")
-    assert len(docker_util.containers_matching("hint_worker_", False)) == 2
-    assert len(docker_util.containers_matching("hint_worker_", True)) == 4
+    assert docker_util.container_exists("hint_worker_calibrate")
+    assert len(docker_util.containers_matching("hint_worker_", False)) == 3
+    assert len(docker_util.containers_matching("hint_worker_", True)) == 5
 
     # We are going to write some data into redis here and later check
     # that it survived the upgrade.
@@ -205,7 +206,8 @@ def test_update_hintr_and_all():
     assert docker_util.container_exists("hint_redis")
     assert docker_util.container_exists("hint_hintr")
     assert docker_util.container_exists("hint_hint")
-    assert len(docker_util.containers_matching("hint_worker_", False)) == 2
+    assert docker_util.container_exists("hint_worker_calibrate")
+    assert len(docker_util.containers_matching("hint_worker_", False)) == 3
 
     redis = obj.containers.get("redis", obj.prefix)
     args_get = ["redis-cli", "GET", "data_persists"]


### PR DESCRIPTION
This uses https://github.com/mrc-ide/hintr/pull/248

I've checked this in a local deploy by bringing up 1 "normal" worker and 1 calibrate worker and
* Trying to run 2 model runs and confirming the 2nd gets queued
* Running calibrate whilst a model is running and confirming it goes to calibrate worker

I guess we could also move this to a constellation service if we wanted to add multiple at some point. This is the sort of thing it would be cool to have monitoring on the worker to see how busy it is and whether there is value in adding more than 1.