### PR TITLE
Fix unable to restart calibration container on "upgrade hintr"

### DIFF
--- a/config/hint.yml
+++ b/config/hint.yml
@@ -16,6 +16,7 @@ hint:
 hintr:
   tag: "master"
   workers: 2
+  calibrate_workers: 1
   volumes:
     results: "hint_results"
     prerun: "hint_prerun"

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -133,8 +133,8 @@ def hint_constellation(cfg):
     # 6. calibrate worker
     worker_ref = cfg.hintr_worker_ref
     calibrate_worker_args = ["--calibrate-only"]
-    calibrate_worker = constellation.ConstellationContainer(
-        "worker_calibrate", worker_ref, args=calibrate_worker_args,
+    calibrate_worker = constellation.ConstellationService(
+        "calibrate_worker", worker_ref, 1, args=calibrate_worker_args,
         mounts=hintr_mounts, environment=hintr_env)
 
     # 7. hintr workers
@@ -165,6 +165,7 @@ def hint_start(obj, cfg, args):
 
 def hint_upgrade_hintr(obj):
     hintr = obj.containers.find("hintr")
+    calibrate_worker = obj.containers.find("calibrate_worker")
     worker = obj.containers.find("worker")
     container = hintr.get(obj.prefix)
 
@@ -179,7 +180,7 @@ def hint_upgrade_hintr(obj):
             container.exec_run(["hintr_stop"])
         docker_util.container_remove_wait(container)
 
-    obj.start(subset=[hintr.name, worker.name])
+    obj.start(subset=[hintr.name, calibrate_worker.name, worker.name])
 
 
 def hint_upgrade_all(obj, db_tag):

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -28,6 +28,8 @@ class HintConfig:
         self.hintr_tag = config.config_string(dat, ["hintr", "tag"],
                                               True, default_tag)
         self.hintr_workers = config.config_integer(dat, ["hintr", "workers"])
+        self.hintr_calibrate_workers = config.config_integer(
+            dat, ["hintr", "calibrate_workers"])
         self.hintr_use_mock_model = config.config_boolean(
             dat, ["hintr", "use_mock_model"], True, False)
 
@@ -134,8 +136,8 @@ def hint_constellation(cfg):
     worker_ref = cfg.hintr_worker_ref
     calibrate_worker_args = ["--calibrate-only"]
     calibrate_worker = constellation.ConstellationService(
-        "calibrate_worker", worker_ref, 1, args=calibrate_worker_args,
-        mounts=hintr_mounts, environment=hintr_env)
+        "calibrate_worker", worker_ref, cfg.hintr_calibrate_workers,
+        args=calibrate_worker_args, mounts=hintr_mounts, environment=hintr_env)
 
     # 7. hintr workers
     worker = constellation.ConstellationService(

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -40,7 +40,8 @@ def test_start_hint():
     assert docker_util.container_exists("hint_hintr")
     assert docker_util.container_exists("hint_hint")
     assert len(docker_util.containers_matching("hint_worker_", False)) == 2
-    assert len(docker_util.containers_matching("hint_calibrate_worker_", False)) == 1
+    assert len(docker_util.containers_matching(
+        "hint_calibrate_worker_", False)) == 1
 
     # Some basic user management
     user = "test@example.com"
@@ -95,7 +96,8 @@ def test_start_hint():
     assert not docker_util.container_exists("hint_hintr")
     assert not docker_util.container_exists("hint_hint")
     assert len(docker_util.containers_matching("hint_worker_", False)) == 0
-    assert len(docker_util.containers_matching("hint_calibrate_worker_", False)) == 0
+    assert len(docker_util.containers_matching(
+        "hint_calibrate_worker_", False)) == 0
 
 
 def test_start_hint_from_cli():
@@ -177,8 +179,10 @@ def test_update_hintr_and_all():
     assert docker_util.container_exists("hint_hint")
     assert len(docker_util.containers_matching("hint_worker_", False)) == 2
     assert len(docker_util.containers_matching("hint_worker_", True)) == 4
-    assert len(docker_util.containers_matching("hint_calibrate_worker", False)) == 1
-    assert len(docker_util.containers_matching("hint_calibrate_worker", True)) == 2
+    assert len(docker_util.containers_matching(
+        "hint_calibrate_worker", False)) == 1
+    assert len(docker_util.containers_matching(
+        "hint_calibrate_worker", True)) == 2
 
     # We are going to write some data into redis here and later check
     # that it survived the upgrade.
@@ -209,7 +213,8 @@ def test_update_hintr_and_all():
     assert docker_util.container_exists("hint_hintr")
     assert docker_util.container_exists("hint_hint")
     assert len(docker_util.containers_matching("hint_worker_", False)) == 2
-    assert len(docker_util.containers_matching("hint_calibrate_worker_", False)) == 1
+    assert len(docker_util.containers_matching(
+        "hint_calibrate_worker_", False)) == 1
 
     redis = obj.containers.get("redis", obj.prefix)
     args_get = ["redis-cli", "GET", "data_persists"]

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -39,8 +39,8 @@ def test_start_hint():
     assert docker_util.container_exists("hint_redis")
     assert docker_util.container_exists("hint_hintr")
     assert docker_util.container_exists("hint_hint")
-    assert docker_util.container_exists("hint_calibrate_worker")
-    assert len(docker_util.containers_matching("hint_worker_", False)) == 3
+    assert len(docker_util.containers_matching("hint_worker_", False)) == 2
+    assert len(docker_util.containers_matching("hint_calibrate_worker_", False)) == 1
 
     # Some basic user management
     user = "test@example.com"
@@ -94,8 +94,8 @@ def test_start_hint():
     assert not docker_util.container_exists("hint_redis")
     assert not docker_util.container_exists("hint_hintr")
     assert not docker_util.container_exists("hint_hint")
-    assert not docker_util.container_exists("hint_calibrate_worker")
     assert len(docker_util.containers_matching("hint_worker_", False)) == 0
+    assert len(docker_util.containers_matching("hint_calibrate_worker_", False)) == 0
 
 
 def test_start_hint_from_cli():
@@ -163,6 +163,7 @@ def test_update_hintr_and_all():
     assert "Pulling docker image db-migrate" not in p
     assert "Stopping previous hintr and workers" in p
     assert "Starting hintr" in p
+    assert "Starting *service* calibrate_worker" in p
     assert "Starting *service* worker" in p
 
     assert docker_util.network_exists("hint_nw")
@@ -174,9 +175,10 @@ def test_update_hintr_and_all():
     assert docker_util.container_exists("hint_redis")
     assert docker_util.container_exists("hint_hintr")
     assert docker_util.container_exists("hint_hint")
-    assert docker_util.container_exists("hint_calibrate_worker")
     assert len(docker_util.containers_matching("hint_worker_", False)) == 2
-    assert len(docker_util.containers_matching("hint_worker_", True)) == 5
+    assert len(docker_util.containers_matching("hint_worker_", True)) == 4
+    assert len(docker_util.containers_matching("hint_calibrate_worker", False)) == 1
+    assert len(docker_util.containers_matching("hint_calibrate_worker", True)) == 2
 
     # We are going to write some data into redis here and later check
     # that it survived the upgrade.
@@ -206,8 +208,8 @@ def test_update_hintr_and_all():
     assert docker_util.container_exists("hint_redis")
     assert docker_util.container_exists("hint_hintr")
     assert docker_util.container_exists("hint_hint")
-    assert docker_util.container_exists("hint_calibrate_worker")
-    assert len(docker_util.containers_matching("hint_worker_", False)) == 3
+    assert len(docker_util.containers_matching("hint_worker_", False)) == 2
+    assert len(docker_util.containers_matching("hint_calibrate_worker_", False)) == 1
 
     redis = obj.containers.get("redis", obj.prefix)
     args_get = ["redis-cli", "GET", "data_persists"]

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -39,7 +39,7 @@ def test_start_hint():
     assert docker_util.container_exists("hint_redis")
     assert docker_util.container_exists("hint_hintr")
     assert docker_util.container_exists("hint_hint")
-    assert docker_util.container_exists("hint_worker_calibrate")
+    assert docker_util.container_exists("hint_calibrate_worker")
     assert len(docker_util.containers_matching("hint_worker_", False)) == 3
 
     # Some basic user management
@@ -94,7 +94,7 @@ def test_start_hint():
     assert not docker_util.container_exists("hint_redis")
     assert not docker_util.container_exists("hint_hintr")
     assert not docker_util.container_exists("hint_hint")
-    assert not docker_util.container_exists("hint_worker_calibrate")
+    assert not docker_util.container_exists("hint_calibrate_worker")
     assert len(docker_util.containers_matching("hint_worker_", False)) == 0
 
 
@@ -174,7 +174,7 @@ def test_update_hintr_and_all():
     assert docker_util.container_exists("hint_redis")
     assert docker_util.container_exists("hint_hintr")
     assert docker_util.container_exists("hint_hint")
-    assert docker_util.container_exists("hint_worker_calibrate")
+    assert docker_util.container_exists("hint_calibrate_worker")
     assert len(docker_util.containers_matching("hint_worker_", False)) == 2
     assert len(docker_util.containers_matching("hint_worker_", True)) == 5
 
@@ -206,7 +206,7 @@ def test_update_hintr_and_all():
     assert docker_util.container_exists("hint_redis")
     assert docker_util.container_exists("hint_hintr")
     assert docker_util.container_exists("hint_hint")
-    assert docker_util.container_exists("hint_worker_calibrate")
+    assert docker_util.container_exists("hint_calibrate_worker")
     assert len(docker_util.containers_matching("hint_worker_", False)) == 3
 
     redis = obj.containers.get("redis", obj.prefix)


### PR DESCRIPTION
The issue we had here was the container was always called `hintr_worker_calibrate` and was not removed when doing `./hint upgrade hintr` so failed to restart as it would try to restart this container and clash with the name. It was also a bit confusing I think in the testing because of the similar names. So this PR will

* Use `hintr_calibrate_worker` for the name of calibrate workers to be more clear about difference and tidy up tests
* Make calibrate workers a ConstellationService which will give them a unique name and mean it can be restarted using `upgrade hintr`
* Explicitly restart this container when calling `upgrade hintr`

I mentioned in a message weirdness with the worker containers not getting removed. It looks like that is intended as the tests themselves check explicitly for exited containers existing. If we want these to be removed I can do this in another PR.

As a slight aside to this I am getting an error when starting or upgrading all on production which is a bit worrying - from the hintr container
```
hint@naomi:~/hint-deploy$ docker logs hint_hintr
Connecting to redis at redis://redis:6379
Starting queue
Error in redis_command(ptr, cmd) : 
  LOADING Redis is loading the dataset in memory
Calls: <Anonymous> ... worker_config_save -> <Anonymous> -> command -> redis_command
Execution halted
```
I've not been able to recreate that locally or on staging though