### PR TITLE
MRC-2112: Wait for redis to be useable before continuing deployment

### DIFF
--- a/scripts/wait_for_redis
+++ b/scripts/wait_for_redis
@@ -4,12 +4,6 @@ wait_for()
     echo "waiting up to $TIMEOUT seconds for redis"
     start_ts=$(date +%s)
     for i in $(seq $TIMEOUT); do
-        # Using redis-cli as:
-        #
-        #   redis-cli -p $PORT ping
-        #
-        # seems heaps nicer but does not actually work properly
-        # because it pulls us up to soon.
         redis-cli -p 6379 ping > /dev/null 2>&1
         result=$?
         if [[ $result -eq 0 ]]; then

--- a/scripts/wait_for_redis
+++ b/scripts/wait_for_redis
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+wait_for()
+{
+    echo "waiting up to $TIMEOUT seconds for redis"
+    start_ts=$(date +%s)
+    for i in $(seq $TIMEOUT); do
+        # Using redis-cli as:
+        #
+        #   redis-cli -p $PORT ping
+        #
+        # seems heaps nicer but does not actually work properly
+        # because it pulls us up to soon.
+        redis-cli -p 6379 ping > /dev/null 2>&1
+        result=$?
+        if [[ $result -eq 0 ]]; then
+            end_ts=$(date +%s)
+            echo "redis is available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+        echo "...still waiting"
+    done
+    return $result
+}
+
+# The variable expansion below is 20s by default, or the argument provided
+# to this script
+TIMEOUT="${1:-20}"
+wait_for
+RESULT=$?
+if [[ $RESULT -ne 0 ]]; then
+  echo "redis did not become available in time"
+fi
+exit $RESULT

--- a/scripts/wait_for_redis
+++ b/scripts/wait_for_redis
@@ -26,4 +26,3 @@ if [[ $RESULT -ne 0 ]]; then
   echo "redis did not become available in time"
 fi
 exit $RESULT
-

--- a/scripts/wait_for_redis
+++ b/scripts/wait_for_redis
@@ -4,7 +4,7 @@ wait_for()
     echo "waiting up to $TIMEOUT seconds for redis"
     start_ts=$(date +%s)
     for i in $(seq $TIMEOUT); do
-        redis-cli -p 6379 ping > /dev/null 2>&1
+        redis-cli -p 6379 ping | grep PONG
         result=$?
         if [[ $result -eq 0 ]]; then
             end_ts=$(date +%s)

--- a/scripts/wait_for_redis
+++ b/scripts/wait_for_redis
@@ -26,3 +26,4 @@ if [[ $RESULT -ne 0 ]]; then
   echo "redis did not become available in time"
 fi
 exit $RESULT
+

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -223,8 +223,9 @@ def hint_user_run(ref, args, cfg):
 
 
 def redis_configure(container, cfg):
-    print("[db] Waiting for redis to come up")
-    docker_util.file_into_container("scripts/wait_for_redis", container, ".", "/wait_for_redis")
+    print("[redis] Waiting for redis to come up")
+    docker_util.file_into_container(
+        "scripts/wait_for_redis", container, ".", "wait_for_redis")
     docker_util.exec_safely(container, ["bash", "/wait_for_redis"])
 
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -202,6 +202,7 @@ def test_update_hintr_and_all():
     assert "Stop 'redis'" in p
     assert "Removing 'redis'" in p
     assert "Starting redis" in p
+    assert "[redis] Waiting for redis to come up" in p
 
     assert docker_util.network_exists("hint_nw")
     assert docker_util.volume_exists("hint_db_data")


### PR DESCRIPTION
This PR will
* Add a script to test if redis can be used

Need this because we have seen on production redis taking a while to load persistent data and become useable. To the point hintr is starting and trying to connect before redis is ready resulting in failed deployments.

Not much testing here, hard to test the checking script itself but the impl is quite simple outside of that. There is a small test that the configure function gets run on container upgrade.