### PR TITLE
Add new configuration for wpia-naomi

### DIFF
--- a/config/wpia-naomi.yml
+++ b/config/wpia-naomi.yml
@@ -1,0 +1,24 @@
+hint:
+  adr_url: https://adr.unaids.org/
+  issue_report_url: VAULT:secret/hint/flow-webhooks/issue-report:url
+  email:
+    password: VAULT:secret/hint/email:password
+
+hintr:
+  workers: 5
+
+proxy:
+  host: wpia-naomi.dide.ic.ac.uk
+  port_http: 80
+  port_https: 443
+
+vault:
+  addr: https://vault.dide.ic.ac.uk:8200
+  auth:
+    method: github
+
+users:
+  add_test_user: false
+
+deploy:
+  protect_data: true


### PR DESCRIPTION
Currently proxy uses a self-signed cert; we will proxy the http part of the app (hint) instead.