### PR TITLE
Update number of workers

### DIFF
--- a/config/production.yml
+++ b/config/production.yml
@@ -5,7 +5,8 @@ hint:
     password: VAULT:secret/hint/email:password
 
 hintr:
-  workers: 9
+  workers: 5
+  calibrate_workers: 2 
 
 proxy:
   host: naomi.unaids.org


### PR DESCRIPTION
This PR will
* Change number of hint workers - this now matches what we have been using on production since the last workshop (I've just been lazy and not updated it in git)
* Adds a second calibrate worker - now we are running downloads async they are being run on the calibrate workers. I think we should make at least 2 of these available because the summary report can be slow generate

If I have time I will try make a kibana graph so we can see idle/busy time over next month and can think about adjusting worker number from that