### PR TITLE
mrc-3367: Add backup and restore scripts

### DIFF
--- a/backup/backup
+++ b/backup/backup
@@ -13,7 +13,7 @@ BACKUP_PATH="$SCRIPT_DIR/$NOW.tar.gz"
 BACKUP_WORKING_DIR="$SCRIPT_DIR/working"
 mkdir $BACKUP_WORKING_DIR
 
-function clean_up {
+clean_up() {
     echo "Backup failed, cleaning up working dir"
     rm -rf $BACKUP_WORKING_DIR
     exit 1

--- a/backup/backup
+++ b/backup/backup
@@ -27,7 +27,7 @@ docker run --rm --volumes-from hint_redis -v $BACKUP_WORKING_DIR:/backup busybox
 docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -cf /backup/prerun_backup.tar -C /prerun .
 docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -cf /backup/results_backup.tar -C /results .
 docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -cf /backup/uploads_backup.tar -C /uploads .
-find $BACKUP_WORKING_DIR -type f -exec md5sum "{}" + >$BACKUP_WORKING_DIR/checklist.chk
+find $BACKUP_WORKING_DIR -type f \( -not -name "checklist.chk" \) -exec md5sum "{}" + >$BACKUP_WORKING_DIR/checklist.chk
 
 tar -cf $BACKUP_PATH -C $BACKUP_WORKING_DIR .
 echo "Backup complete, saved at $BACKUP_PATH"

--- a/backup/backup
+++ b/backup/backup
@@ -21,10 +21,10 @@ clean_up() {
 trap clean_up ERR
 
 docker exec hint_db pg_dump -U postgres hint >$BACKUP_WORKING_DIR/db_dump.sql
-docker run --rm --volumes-from hint_redis -v $BACKUP_WORKING_DIR:/backup busybox tar -czf /backup/redis_backup.tar.gz /data
-docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -czf /backup/prerun_backup.tar.gz /prerun
-docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -czf /backup/results_backup.tar.gz /results
-docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -czf /backup/uploads_backup.tar.gz /uploads
+docker run --rm --volumes-from hint_redis -v $BACKUP_WORKING_DIR:/backup busybox tar -czf /backup/redis_backup.tar.gz -C /data .
+docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -czf /backup/prerun_backup.tar.gz -C /prerun .
+docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -czf /backup/results_backup.tar.gz -C /results .
+docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -czf /backup/uploads_backup.tar.gz -C /uploads .
 
 tar -czf $BACKUP_PATH -C $BACKUP_WORKING_DIR .
 echo "Backup complete, saved at $BACKUP_PATH"

--- a/backup/backup
+++ b/backup/backup
@@ -2,17 +2,30 @@
 
 ## Backup all volumes of data used by Naomi, namely:
 ## db data, redis data, uploaded files, prerun files and results
-set -ex
+set -e
 
-BACKUP_ROOT="$(
+SCRIPT_DIR="$(
     cd -- "$(dirname "$0")" >/dev/null 2>&1
     pwd -P
 )"
 NOW=$(date +'%Y_%d_%m-%H_%M_%S')
-BACKUP_PATH="$BACKUP_ROOT/$NOW"
+BACKUP_PATH="$SCRIPT_DIR/$NOW"
+BACKUP_WORKING_DIR="$SCRIPT_DIR/working"
+mkdir $BACKUP_WORKING_DIR
 
-docker run --rm --volumes-from hint_db -v $BACKUP_PATH:/backup busybox tar -czf /backup/pgdata_backup.tar /pgdata
-docker run --rm --volumes-from hint_redis -v $BACKUP_PATH:/backup busybox tar -czf /backup/redis_backup.tar /data
-docker run --rm --volumes-from hint_hintr -v $BACKUP_PATH:/backup busybox tar -czf /backup/prerun_backup.tar /prerun
-docker run --rm --volumes-from hint_hintr -v $BACKUP_PATH:/backup busybox tar -czf /backup/results_backup.tar /results
-docker run --rm --volumes-from hint_hintr -v $BACKUP_PATH:/backup busybox tar -czf /backup/uploads_backup.tar /uploads
+function clean_up {
+    echo "Backup failed, cleaning up working dir"
+    rm -rf $BACKUP_WORKING_DIR
+    exit 1
+}
+trap clean_up ERR
+
+docker run --rm --volumes-from hint_db --network hint_nw -v $BACKUP_WORKING_DIR:/backup postgres:10.3 pg_dump -U postgres hint >/backup/db_dump.sql
+docker run --rm --volumes-from hint_redis -v $BACKUP_WORKING_DIR:/backup busybox tar -czf /backup/redis_backup.tar /data
+docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -czf /backup/prerun_backup.tar /prerun
+docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -czf /backup/results_backup.tar /results
+docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -czf /backup/uploads_backup.tar /uploads
+
+tar -czf $BACKUP_PATH $BACKUP_WORKING_DIR
+echo "Backup complete, saved at $BACKUP_PATH"
+rm -r $BACKUP_WORKING_DIR

--- a/backup/backup
+++ b/backup/backup
@@ -23,17 +23,7 @@ clean_up() {
 trap 'clean_up ${LINENO} "$BASH_COMMAND"' ERR
 
 docker exec hint_db pg_dumpall -U postgres >$BACKUP_WORKING_DIR/db_dump.sql
-docker exec hint_redis redis-cli BGSAVE
-waiting=0
-wait_time=0
-while [ $waiting -eq 0 ]; do
-    sleep 2
-    wait_time=$(($wait_time + 2))
-    echo "Polling redis for backup complete, waited $wait_time seconds"
-    docker exec hint_redis /bin/bash -c "redis-cli INFO PERSISTENCE | grep -q \"rdb_bgsave_in_progress:1\"" || waiting=$?
-done
-echo "Redis backup complete"
-docker cp hint_redis:/data/dump.rdb $BACKUP_WORKING_DIR
+docker run --rm --volumes-from hint_redis -v $BACKUP_WORKING_DIR:/backup busybox tar -cf /backup/redis_backup.tar -C /data .
 docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -cf /backup/prerun_backup.tar -C /prerun .
 docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -cf /backup/results_backup.tar -C /results .
 docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -cf /backup/uploads_backup.tar -C /uploads .

--- a/backup/backup
+++ b/backup/backup
@@ -26,6 +26,6 @@ docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox
 docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -czf /backup/results_backup.tar.gz /results
 docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -czf /backup/uploads_backup.tar.gz /uploads
 
-tar -czf $BACKUP_PATH $BACKUP_WORKING_DIR
+tar -czf $BACKUP_PATH -C $BACKUP_WORKING_DIR .
 echo "Backup complete, saved at $BACKUP_PATH"
 rm -rf $BACKUP_WORKING_DIR

--- a/backup/backup
+++ b/backup/backup
@@ -2,7 +2,7 @@
 
 ## Backup all volumes of data used by Naomi, namely:
 ## db data, redis data, uploaded files, prerun files and results
-set -e
+set -eE
 
 SCRIPT_DIR="$(
     cd -- "$(dirname "$0")" >/dev/null 2>&1

--- a/backup/backup
+++ b/backup/backup
@@ -30,6 +30,7 @@ docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox
 find $BACKUP_WORKING_DIR -type f \( -not -name "checklist.chk" \) -exec md5sum "{}" + >$BACKUP_WORKING_DIR/checklist.chk
 
 VAULT_PATH="secret/hint/$HOSTNAME/cipher"
+VAULT_ADDR="https://vault.dide.ic.ac.uk:8200"
 echo "Do you want to backup private & public keys to secure ADR keys to vault?"
 echo "!!This will overwrite any existing entry at '$VAULT_PATH' in vault!!"
 echo "You do not need to do this if you plan to restore to the same server, but if you want to load the backup onto"
@@ -37,11 +38,11 @@ echo "another server and have the user entered ADR keys still work then you need
 read -p "Backup keys? y/n" -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]; then
-    vault login -address="https://vault.dide.ic.ac.uk:8200" -method=github
+    vault login -address=$VAULT_ADDR -method=github
     PUBLIC_KEY=$(docker run --rm --volumes-from hint_hint busybox cat /etc/hint/token_key/public_key.der | base64 --wrap=0)
     PRIVATE_KEY=$(docker run --rm --volumes-from hint_hint busybox cat /etc/hint/token_key/private_key.der | base64 --wrap=0)
     echo "Writing to $VAULT_PATH"
-    vault write -address="https://vault.dide.ic.ac.uk:8200" $VAULT_PATH public=$PUBLIC_KEY private=$PRIVATE_KEY
+    vault write -address=$VAULT_ADDR $VAULT_PATH public=$PUBLIC_KEY private=$PRIVATE_KEY
     echo "$VAULT_PATH" >$BACKUP_WORKING_DIR/cipher_path
 fi
 

--- a/backup/backup
+++ b/backup/backup
@@ -24,13 +24,13 @@ trap 'clean_up ${LINENO} "$BASH_COMMAND"' ERR
 
 docker exec hint_db pg_dump -U postgres hint >$BACKUP_WORKING_DIR/db_dump.sql
 docker exec hint_redis redis-cli BGSAVE
-running=0
+waiting=0
 wait_time=0
-while [ $running -eq 0 ]; do
+while [ $waiting -eq 0 ]; do
     sleep 2
     wait_time=$(($wait_time + 2))
     echo "Polling redis for backup complete, waited $wait_time seconds"
-    docker exec hint_redis /bin/bash -c "redis-cli INFO PERSISTENCE | grep -q \"rdb_bgsave_in_progress:1\"" || running=$?
+    docker exec hint_redis /bin/bash -c "redis-cli INFO PERSISTENCE | grep -q \"rdb_bgsave_in_progress:1\"" || waiting=$?
 done
 echo "Redis backup complete"
 docker cp hint_redis:/data/dump.rdb $BACKUP_WORKING_DIR

--- a/backup/backup
+++ b/backup/backup
@@ -21,7 +21,17 @@ clean_up() {
 trap clean_up ERR
 
 docker exec hint_db pg_dump -U postgres hint >$BACKUP_WORKING_DIR/db_dump.sql
-docker run --rm --volumes-from hint_redis -v $BACKUP_WORKING_DIR:/backup busybox tar -cf /backup/redis_backup.tar -C /data .
+docker exec hint_redis redis-cli BGSAVE
+finished=0
+wait_time=0
+while [ $finished -eq 0 ]; do
+    sleep 2
+    wait_time=$wait_time + 2
+    echo "Polling redis for backup complete, waited $wait_time seconds"
+    docker exec hint_redis redis-cli INFO PERSISTENCE | grep -q "rdb_bgsave_in_progress:1"
+    finished=$?
+done
+docker cp hint_redis dump.rdb $BACKUP_WORKING_DIR
 docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -cf /backup/prerun_backup.tar -C /prerun .
 docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -cf /backup/results_backup.tar -C /results .
 docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -cf /backup/uploads_backup.tar -C /uploads .

--- a/backup/backup
+++ b/backup/backup
@@ -9,7 +9,7 @@ SCRIPT_DIR="$(
     pwd -P
 )"
 NOW=$(date +'%Y_%d_%m-%H_%M_%S')
-BACKUP_PATH="$SCRIPT_DIR/$NOW"
+BACKUP_PATH="$SCRIPT_DIR/$NOW.tar.gz"
 BACKUP_WORKING_DIR="$SCRIPT_DIR/working"
 mkdir $BACKUP_WORKING_DIR
 
@@ -20,12 +20,12 @@ function clean_up {
 }
 trap clean_up ERR
 
-docker run --rm --volumes-from hint_db --network hint_nw -v $BACKUP_WORKING_DIR:/backup postgres:10.3 pg_dump -U postgres hint >/backup/db_dump.sql
-docker run --rm --volumes-from hint_redis -v $BACKUP_WORKING_DIR:/backup busybox tar -czf /backup/redis_backup.tar /data
-docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -czf /backup/prerun_backup.tar /prerun
-docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -czf /backup/results_backup.tar /results
-docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -czf /backup/uploads_backup.tar /uploads
+docker exec hint_db pg_dump -U postgres hint >$BACKUP_WORKING_DIR/db_dump.sql
+docker run --rm --volumes-from hint_redis -v $BACKUP_WORKING_DIR:/backup busybox tar -czf /backup/redis_backup.tar.gz /data
+docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -czf /backup/prerun_backup.tar.gz /prerun
+docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -czf /backup/results_backup.tar.gz /results
+docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -czf /backup/uploads_backup.tar.gz /uploads
 
 tar -czf $BACKUP_PATH $BACKUP_WORKING_DIR
 echo "Backup complete, saved at $BACKUP_PATH"
-rm -r $BACKUP_WORKING_DIR
+rm -rf $BACKUP_WORKING_DIR

--- a/backup/backup
+++ b/backup/backup
@@ -31,15 +31,16 @@ find $BACKUP_WORKING_DIR -type f \( -not -name "checklist.chk" \) -exec md5sum "
 
 vault_path="secret/hint/$HOSTNAME/cipher"
 echo "Do you want to backup private & public keys to secure ADR keys to vault?"
-echo "!!This will overwrite an existing entry at this path in vault!!"
+echo "!!This will overwrite any existing entry at '$vault_path' in vault!!"
 echo "You do not need to do this if you plan to restore to the same server, but if you want to load the backup onto"
 echo "another server and have the user entered ADR keys still work then you need backup these keys"
-read -p "Backup keys?" -n 1 -r
+read -p "Backup keys? y/n" -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]; then
-    vault login -method=github
-    public_key=$(docker run --rm --volumes-from hint_hint busybox cat /etc/hint/token_key/public_key.der)
-    private_key=$(docker run --rm --volumes-from hint_hint busybox cat /etc/hint/token_key/private_key.der)
+    vault login -address="https://vault.dide.ic.ac.uk:8200" -method=github
+    public_key=$(docker run --rm --volumes-from hint_hint busybox cat /etc/hint/token_key/public_key.der | base64 --wrap=0)
+    private_key=$(docker run --rm --volumes-from hint_hint busybox cat /etc/hint/token_key/private_key.der | base64 --wrap=0)
+    echo "Writing to $vault_path"
     vault write $vault_path public=$public_key private=$private_key
 fi
 

--- a/backup/backup
+++ b/backup/backup
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+## Backup all volumes of data used by Naomi, namely:
+## db data, redis data, uploaded files, prerun files and results
+set -ex
+
+WD=$(dirname "$0")
+NOW=$(date +'%Y_%d_%m-%H_%M_%S')
+mkdir $NOW
+BACKUP_PATH="$WD/$NOW"
+
+docker run --rm --volumes-from hint_db -v $BACKUP_PATH:/backup busybox tar -czvf /backup/pgdata_backup.tar /pgdata
+docker run --rm --volumes-from hint_redis -v $BACKUP_PATH:/backup busybox tar -czvf /backup/redis_backup.tar /data
+docker run --rm --volumes-from hint_hintr -v $BACKUP_PATH:/backup busybox tar -czvf /backup/prerun_backup.tar /prerun
+docker run --rm --volumes-from hint_hintr -v $BACKUP_PATH:/backup busybox tar -czvf /backup/results_backup.tar /results
+docker run --rm --volumes-from hint_hintr -v $BACKUP_PATH:/backup busybox tar -czvf /backup/uploads_backup.tar /uploads

--- a/backup/backup
+++ b/backup/backup
@@ -22,7 +22,7 @@ clean_up() {
 }
 trap 'clean_up ${LINENO} "$BASH_COMMAND"' ERR
 
-docker exec hint_db pg_dump -U postgres hint >$BACKUP_WORKING_DIR/db_dump.sql
+docker exec hint_db pg_dumpall -U postgres >$BACKUP_WORKING_DIR/db_dump.sql
 docker exec hint_redis redis-cli BGSAVE
 waiting=0
 wait_time=0

--- a/backup/backup
+++ b/backup/backup
@@ -29,6 +29,20 @@ docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox
 docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -cf /backup/uploads_backup.tar -C /uploads .
 find $BACKUP_WORKING_DIR -type f \( -not -name "checklist.chk" \) -exec md5sum "{}" + >$BACKUP_WORKING_DIR/checklist.chk
 
+vault_path="secret/hint/$HOSTNAME/cipher"
+echo "Do you want to backup private & public keys to secure ADR keys to vault?"
+echo "!!This will overwrite an existing entry at this path in vault!!"
+echo "You do not need to do this if you plan to restore to the same server, but if you want to load the backup onto"
+echo "another server and have the user entered ADR keys still work then you need backup these keys"
+read -p "Backup keys?" -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    vault login -method=github
+    public_key=$(docker run --rm --volumes-from hint_hint busybox cat /etc/hint/token_key/public_key.der)
+    private_key=$(docker run --rm --volumes-from hint_hint busybox cat /etc/hint/token_key/private_key.der)
+    vault write $vault_path public=$public_key private=$private_key
+fi
+
 tar -cf $BACKUP_PATH -C $BACKUP_WORKING_DIR .
 echo "Backup complete, saved at $BACKUP_PATH"
 rm -rf $BACKUP_WORKING_DIR

--- a/backup/backup
+++ b/backup/backup
@@ -9,7 +9,7 @@ SCRIPT_DIR="$(
     pwd -P
 )"
 NOW=$(date +'%Y_%d_%m-%H_%M_%S')
-BACKUP_PATH="$SCRIPT_DIR/$NOW.tar.gz"
+BACKUP_PATH="$SCRIPT_DIR/$NOW.tar"
 BACKUP_WORKING_DIR="$SCRIPT_DIR/working"
 mkdir $BACKUP_WORKING_DIR
 
@@ -21,11 +21,12 @@ clean_up() {
 trap clean_up ERR
 
 docker exec hint_db pg_dump -U postgres hint >$BACKUP_WORKING_DIR/db_dump.sql
-docker run --rm --volumes-from hint_redis -v $BACKUP_WORKING_DIR:/backup busybox tar -czf /backup/redis_backup.tar.gz -C /data .
-docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -czf /backup/prerun_backup.tar.gz -C /prerun .
-docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -czf /backup/results_backup.tar.gz -C /results .
-docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -czf /backup/uploads_backup.tar.gz -C /uploads .
+docker run --rm --volumes-from hint_redis -v $BACKUP_WORKING_DIR:/backup busybox tar -cf /backup/redis_backup.tar -C /data .
+docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -cf /backup/prerun_backup.tar -C /prerun .
+docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -cf /backup/results_backup.tar -C /results .
+docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -cf /backup/uploads_backup.tar -C /uploads .
+find $BACKUP_WORKING_DIR -type f -exec md5sum "{}" + >$BACKUP_WORKING_DIR/checklist.chk
 
-tar -czf $BACKUP_PATH -C $BACKUP_WORKING_DIR .
+tar -cf $BACKUP_PATH -C $BACKUP_WORKING_DIR .
 echo "Backup complete, saved at $BACKUP_PATH"
 rm -rf $BACKUP_WORKING_DIR

--- a/backup/backup
+++ b/backup/backup
@@ -4,7 +4,10 @@
 ## db data, redis data, uploaded files, prerun files and results
 set -ex
 
-WD=$(dirname "$0")
+WD="$(
+    cd -- "$(dirname "$0")" >/dev/null 2>&1
+    pwd -P
+)"
 NOW=$(date +'%Y_%d_%m-%H_%M_%S')
 mkdir $NOW
 BACKUP_PATH="$WD/$NOW"

--- a/backup/backup
+++ b/backup/backup
@@ -4,16 +4,15 @@
 ## db data, redis data, uploaded files, prerun files and results
 set -ex
 
-WD="$(
+BACKUP_ROOT="$(
     cd -- "$(dirname "$0")" >/dev/null 2>&1
     pwd -P
 )"
 NOW=$(date +'%Y_%d_%m-%H_%M_%S')
-mkdir $NOW
-BACKUP_PATH="$WD/$NOW"
+BACKUP_PATH="$BACKUP_ROOT/$NOW"
 
-docker run --rm --volumes-from hint_db -v $BACKUP_PATH:/backup busybox tar -czvf /backup/pgdata_backup.tar /pgdata
-docker run --rm --volumes-from hint_redis -v $BACKUP_PATH:/backup busybox tar -czvf /backup/redis_backup.tar /data
-docker run --rm --volumes-from hint_hintr -v $BACKUP_PATH:/backup busybox tar -czvf /backup/prerun_backup.tar /prerun
-docker run --rm --volumes-from hint_hintr -v $BACKUP_PATH:/backup busybox tar -czvf /backup/results_backup.tar /results
-docker run --rm --volumes-from hint_hintr -v $BACKUP_PATH:/backup busybox tar -czvf /backup/uploads_backup.tar /uploads
+docker run --rm --volumes-from hint_db -v $BACKUP_PATH:/backup busybox tar -czf /backup/pgdata_backup.tar /pgdata
+docker run --rm --volumes-from hint_redis -v $BACKUP_PATH:/backup busybox tar -czf /backup/redis_backup.tar /data
+docker run --rm --volumes-from hint_hintr -v $BACKUP_PATH:/backup busybox tar -czf /backup/prerun_backup.tar /prerun
+docker run --rm --volumes-from hint_hintr -v $BACKUP_PATH:/backup busybox tar -czf /backup/results_backup.tar /results
+docker run --rm --volumes-from hint_hintr -v $BACKUP_PATH:/backup busybox tar -czf /backup/uploads_backup.tar /uploads

--- a/backup/backup
+++ b/backup/backup
@@ -14,24 +14,26 @@ BACKUP_WORKING_DIR="$SCRIPT_DIR/working"
 mkdir $BACKUP_WORKING_DIR
 
 clean_up() {
-    echo "Backup failed, cleaning up working dir"
+    local lineno=$1
+    local msg=$2
+    echo "Backup failed at $lineno: $msg"
     rm -rf $BACKUP_WORKING_DIR
     exit 1
 }
-trap clean_up ERR
+trap 'clean_up ${LINENO} "$BASH_COMMAND"' ERR
 
 docker exec hint_db pg_dump -U postgres hint >$BACKUP_WORKING_DIR/db_dump.sql
 docker exec hint_redis redis-cli BGSAVE
-finished=0
+running=0
 wait_time=0
-while [ $finished -eq 0 ]; do
+while [ $running -eq 0 ]; do
     sleep 2
-    wait_time=$wait_time + 2
+    wait_time=$(($wait_time + 2))
     echo "Polling redis for backup complete, waited $wait_time seconds"
-    docker exec hint_redis redis-cli INFO PERSISTENCE | grep -q "rdb_bgsave_in_progress:1"
-    finished=$?
+    docker exec hint_redis /bin/bash -c "redis-cli INFO PERSISTENCE | grep -q \"rdb_bgsave_in_progress:1\"" || running=$?
 done
-docker cp hint_redis dump.rdb $BACKUP_WORKING_DIR
+echo "Redis backup complete"
+docker cp hint_redis:/data/dump.rdb $BACKUP_WORKING_DIR
 docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -cf /backup/prerun_backup.tar -C /prerun .
 docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -cf /backup/results_backup.tar -C /results .
 docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -cf /backup/uploads_backup.tar -C /uploads .

--- a/backup/backup
+++ b/backup/backup
@@ -29,19 +29,20 @@ docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox
 docker run --rm --volumes-from hint_hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -cf /backup/uploads_backup.tar -C /uploads .
 find $BACKUP_WORKING_DIR -type f \( -not -name "checklist.chk" \) -exec md5sum "{}" + >$BACKUP_WORKING_DIR/checklist.chk
 
-vault_path="secret/hint/$HOSTNAME/cipher"
+VAULT_PATH="secret/hint/$HOSTNAME/cipher"
 echo "Do you want to backup private & public keys to secure ADR keys to vault?"
-echo "!!This will overwrite any existing entry at '$vault_path' in vault!!"
+echo "!!This will overwrite any existing entry at '$VAULT_PATH' in vault!!"
 echo "You do not need to do this if you plan to restore to the same server, but if you want to load the backup onto"
 echo "another server and have the user entered ADR keys still work then you need backup these keys"
 read -p "Backup keys? y/n" -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]; then
     vault login -address="https://vault.dide.ic.ac.uk:8200" -method=github
-    public_key=$(docker run --rm --volumes-from hint_hint busybox cat /etc/hint/token_key/public_key.der | base64 --wrap=0)
-    private_key=$(docker run --rm --volumes-from hint_hint busybox cat /etc/hint/token_key/private_key.der | base64 --wrap=0)
-    echo "Writing to $vault_path"
-    vault write $vault_path public=$public_key private=$private_key
+    PUBLIC_KEY=$(docker run --rm --volumes-from hint_hint busybox cat /etc/hint/token_key/public_key.der | base64 --wrap=0)
+    PRIVATE_KEY=$(docker run --rm --volumes-from hint_hint busybox cat /etc/hint/token_key/private_key.der | base64 --wrap=0)
+    echo "Writing to $VAULT_PATH"
+    vault write -address="https://vault.dide.ic.ac.uk:8200" $VAULT_PATH public=$PUBLIC_KEY private=$PRIVATE_KEY
+    echo "$VAULT_PATH" >$BACKUP_WORKING_DIR/cipher_path
 fi
 
 tar -cf $BACKUP_PATH -C $BACKUP_WORKING_DIR .

--- a/backup/restore
+++ b/backup/restore
@@ -21,8 +21,8 @@ assert_all_data_exists() {
 }
 
 restore() {
-    docker exec hint_db psql -U postgres -c "DROP DATABASE hint"
-    docker exec hint_db psql -U postgres -c "CREATE DATABASE hint"
+    docker exec hint_db dropdb -f hint
+    docker exec hint_db createdb -T template0 hint
     cat $1/db_dump.sql | docker exec -i hint_db psql -U postgres hint
     docker run --rm --volumes-from hint_redis -v $1:/backup busybox tar -xvf /backup/redis_backup.tar.gz -C /data
     docker run --rm --volumes-from hint_hintr -v $1:/backup busybox tar -xvf /backup/prerun_backup.tar.gz -C /prerun

--- a/backup/restore
+++ b/backup/restore
@@ -56,9 +56,9 @@ restore() {
     docker exec -i restore_pg createdb -U postgres hint
     docker exec -i restore_pg psql -U postgres -d hint <$1/db_dump.sql
     docker stop restore_pg
-    docker run --rm -v hint_redis_data:/data --name helper busybox true
+    docker run -v hint_redis_data:/data --name helper busybox true
     docker cp $1/dump.rdb helper:/data
-    docker stop helper
+    docker rm helper
     docker run --rm -v hint_prerun:/data -v $1:/backup busybox tar -xvf /backup/prerun_backup.tar -C /data
     docker run --rm -v hint_results:/data -v $1:/backup busybox tar -xvf /backup/results_backup.tar -C /data
     docker run --rm -v hint_uploads:/data -v $1:/backup busybox tar -xvf /backup/uploads_backup.tar -C /data
@@ -75,7 +75,8 @@ mkdir $RESTORE_WORKING_DIR
 clean_up() {
     echo "Restore failed, cleaning up working dir"
     rm -rf $RESTORE_WORKING_DIR
-    docker stop restore_pg helper
+    docker stop restore_pg
+    docker rm helper
     exit 1
 }
 trap clean_up ERR

--- a/backup/restore
+++ b/backup/restore
@@ -53,12 +53,12 @@ restore() {
     create_volumes
     docker run --rm -d -v hint_db_data:/pgdata -e POSTGRES_PASSWORD=password -e PGDATA=/pgdata --name restore_pg postgres:10.3
     sleep 5 ## Ideally here we would do something cleverer and poll for db being ready to accept connections
-    docker exec -i restore_pg psql -U postgres postgres <$1/db_dump.sql
+    docker exec -i restore_pg psql -U postgres postgres <$1/db_dump.sql >/dev/null
     docker stop restore_pg
-    docker run --rm -v hint_redis_data:/data -v $1:/backup busybox tar -xvf /backup/redis_backup.tar -C /data
-    docker run --rm -v hint_prerun:/data -v $1:/backup busybox tar -xvf /backup/prerun_backup.tar -C /data
-    docker run --rm -v hint_results:/data -v $1:/backup busybox tar -xvf /backup/results_backup.tar -C /data
-    docker run --rm -v hint_uploads:/data -v $1:/backup busybox tar -xvf /backup/uploads_backup.tar -C /data
+    docker run --rm -v hint_redis_data:/data -v $1:/backup busybox tar -xf /backup/redis_backup.tar -C /data
+    docker run --rm -v hint_prerun:/data -v $1:/backup busybox tar -xf /backup/prerun_backup.tar -C /data
+    docker run --rm -v hint_results:/data -v $1:/backup busybox tar -xf /backup/results_backup.tar -C /data
+    docker run --rm -v hint_uploads:/data -v $1:/backup busybox tar -xf /backup/uploads_backup.tar -C /data
 }
 
 restore_key() {
@@ -66,10 +66,10 @@ restore_key() {
     echo "Restoring keys from vault path '$VAULT_PATH'"
     VAULT_ADDR="https://vault.dide.ic.ac.uk:8200"
     vault login -address=$VAULT_ADDR -method=github
-    PUBLIC_KEY=$(vault read -field=public $VAULT_PATH | base64 --decode --ignore-garbage)
-    PRIVATE_KEY=$(vault read -field=private $VAULT_PATH | base64 --decode --ignore-garbage)
+    PUBLIC_KEY=$(vault read -address=$VAULT_ADDR -field=public $VAULT_PATH)
+    PRIVATE_KEY=$(vault read -address=$VAULT_ADDR -field=private $VAULT_PATH)
     docker run --rm -v hint_config:/data busybox sh -c \
-        "mkdir /data/token_key && echo $PUBLIC_KEY >/data/token_key/public_key.der && echo $PRIVATE_KEY >/data/token_key/private_key.der"
+        "mkdir /data/token_key && echo $PUBLIC_KEY | base64 -d >/data/token_key/public_key.der && echo $PRIVATE_KEY | base64 -d >/data/token_key/private_key.der"
 }
 
 assert_file_exists $1

--- a/backup/restore
+++ b/backup/restore
@@ -12,32 +12,39 @@ assert_file_exists() {
 }
 
 assert_all_data_exists() {
-    if !([ ! -z "$1" ] && [ -d "$1" ] && [ -f "$1/pgdata_backup.tar" ] && [ -f "$1/redis_backup.tar" ] &&
-        [ -f "$1/prerun_backup.tar" ] && [ -f "$1/results_backup.tar" ] && [ -f "$1/uploads_backup.tar" ]); then
+    if !([ ! -z "$1" ] && [ -d "$1" ] && [ -f "$1/db_dump.sql" ] && [ -f "$1/redis_backup.tar.gz" ] &&
+        [ -f "$1/prerun_backup.tar.gz" ] && [ -f "$1/results_backup.tar.gz" ] && [ -f "$1/uploads_backup.tar.gz" ]); then
         echo "Backup dir $1 is incomplete"
         echo "Usage: restore <backup_dir>"
         exit 1
     fi
 }
 
-unzip() {
-    tar -xvf $1 -C $2
-}
-
 restore() {
     docker exec hint_db psql -U postgres hint <$1/db_dump.sql
-    docker run --rm --volumes-from hint_redis -v $1:/backup busybox tar -xvf /backup/redis_backup.tar /data
-    docker run --rm --volumes-from hint_hintr -v $1:/backup busybox tar -xvf /backup/prerun_backup.tar /prerun
-    docker run --rm --volumes-from hint_hintr -v $1:/backup busybox tar -xvf /backup/results_backup.tar /results
-    docker run --rm --volumes-from hint_hintr -v $1:/backup busybox tar -xvf /backup/uploads_backup.tar /uploads
+    docker run --rm --volumes-from hint_redis -v $1:/backup busybox tar -xvf /backup/redis_backup.tar.gz -C /data
+    docker run --rm --volumes-from hint_hintr -v $1:/backup busybox tar -xvf /backup/prerun_backup.tar.gz -C /prerun
+    docker run --rm --volumes-from hint_hintr -v $1:/backup busybox tar -xvf /backup/results_backup.tar.gz -C /results
+    docker run --rm --volumes-from hint_hintr -v $1:/backup busybox tar -xvf /backup/uploads_backup.tar.gz -C /uploads
 }
 
-ABSOLUTE_PATH="$(
+assert_file_exists $1
+RESTORE_DIR="$(
     cd "$(dirname "$1")"
     pwd
-)/$(basename "$1")"
-WORKING_DIR=$ABSOLUTE_PATH/working
-assert_file_exists $1
-unzip $1 $WORKING_DIR
-assert_all_data_exists $WORKING_DIR
-restore $WORKING_DIR
+)"
+RESTORE_PATH=$RESTORE_DIR/$(basename "$1")
+RESTORE_WORKING_DIR=$RESTORE_DIR/working
+mkdir $RESTORE_WORKING_DIR
+clean_up() {
+    echo "Restore failed, cleaning up working dir"
+    rm -rf $RESTORE_WORKING_DIR
+    exit 1
+}
+trap clean_up ERR
+
+tar -xvf $1 -C $RESTORE_WORKING_DIR
+assert_all_data_exists $RESTORE_WORKING_DIR
+restore $RESTORE_WORKING_DIR
+echo "Restore complete"
+rm -rf $RESTORE_WORKING_DIR

--- a/backup/restore
+++ b/backup/restore
@@ -5,14 +5,6 @@ set -eE
 
 volumes=("hint_db_data" "hint_redis_data" "hint_prerun" "hint_results" "hint_uploads" "hint_config")
 
-assert_file_exists $1
-RESTORE_DIR="$(
-    cd "$(dirname "$1")"
-    pwd
-)"
-RESTORE_PATH=$RESTORE_DIR/$(basename "$1")
-RESTORE_WORKING_DIR=$RESTORE_DIR/working
-mkdir $RESTORE_WORKING_DIR
 clean_up() {
     echo "Restore failed, cleaning up working dir"
     rm -rf $RESTORE_WORKING_DIR
@@ -20,7 +12,6 @@ clean_up() {
     docker rm helper || true
     exit 1
 }
-trap clean_up ERR
 
 array_contains() {
     local seeking=$1
@@ -114,6 +105,16 @@ restore_key() {
     docker run --rm -v hint_config:/data busybox sh -c \
         "mkdir /data/token_key && echo $PUBLIC_KEY | base64 -d >/data/token_key/public_key.der && echo $PRIVATE_KEY | base64 -d >/data/token_key/private_key.der"
 }
+
+assert_file_exists $1
+RESTORE_DIR="$(
+    cd "$(dirname "$1")"
+    pwd
+)"
+RESTORE_PATH=$RESTORE_DIR/$(basename "$1")
+RESTORE_WORKING_DIR=$RESTORE_DIR/working
+mkdir $RESTORE_WORKING_DIR
+trap clean_up ERR
 
 tar -xvf $1 -C $RESTORE_WORKING_DIR
 md5sum --check $RESTORE_WORKING_DIR/checklist.chk

--- a/backup/restore
+++ b/backup/restore
@@ -51,7 +51,7 @@ create_volumes() {
 
 restore() {
     create_volumes
-    docker run --rm -d -v hint_db_data:/pgdata -e POSTGRES_PASSWORD=password --name restore_pg postgres:10.3
+    docker run --rm -d -v hint_db_data:/pgdata -e POSTGRES_PASSWORD=password -e PGDATA=/pgdata --name restore_pg postgres:10.3
     sleep 10 ## Ideally here we would do something cleverer and poll for db being ready to accept connections
     docker exec -i restore_pg createdb -U postgres hint
     docker exec -i restore_pg psql -U postgres -d hint <$1/db_dump.sql

--- a/backup/restore
+++ b/backup/restore
@@ -51,11 +51,14 @@ create_volumes() {
 
 restore() {
     create_volumes
-    docker run --rm -v hint_db_data:/pgdata -v $1:/backup postgres:10-alpine -c "cat /backup/db_dump.sql | psql -U postgres hint"
-    docker run -v hint_redis_data:/ --name helper busybox true
-    docker cp $1/dump.rdb helper:/
-    docker rm helper
-    docker cp run --rm -v hint_redis_data:/data $1:/backup redis:5.0
+    docker run --rm -d -v hint_db_data:/pgdata -e POSTGRES_PASSWORD=password --name restore_pg postgres:10.3
+    sleep 10 ## Ideally here we would do something cleverer and poll for db being ready to accept connections
+    docker exec -i restore_pg createdb -U postgres hint
+    docker exec -i restore_pg psql -U postgres -d hint <$1/db_dump.sql
+    docker stop restore_pg
+    docker run --rm -v hint_redis_data:/data --name helper busybox true
+    docker cp $1/dump.rdb helper:/data
+    docker stop helper
     docker run --rm -v hint_prerun:/data -v $1:/backup busybox tar -xvf /backup/prerun_backup.tar -C /data
     docker run --rm -v hint_results:/data -v $1:/backup busybox tar -xvf /backup/results_backup.tar -C /data
     docker run --rm -v hint_uploads:/data -v $1:/backup busybox tar -xvf /backup/uploads_backup.tar -C /data
@@ -72,6 +75,7 @@ mkdir $RESTORE_WORKING_DIR
 clean_up() {
     echo "Restore failed, cleaning up working dir"
     rm -rf $RESTORE_WORKING_DIR
+    docker stop restore_pg helper
     exit 1
 }
 trap clean_up ERR

--- a/backup/restore
+++ b/backup/restore
@@ -13,12 +13,18 @@ function check_all_data_exists {
         (-f "$1/prerun_backup.tar") && (-f "$1/results_backup.tar") && (-f "$1/uploads_backup.tar")
 }
 
-function restore {
-    docker run --rm --volumes-from hint_db -v $BACKUP_ROOT:/backup busybox tar -xvf /backup/pgdata_backup.tar /pgdata
-    docker run --rm --volumes-from hint_redis -v $BACKUP_ROOT:/backup busybox tar -xvf /backup/redis_backup.tar /data
-    docker run --rm --volumes-from hint_hintr -v $BACKUP_ROOT:/backup busybox tar -xvf /backup/prerun_backup.tar /prerun
-    docker run --rm --volumes-from hint_hintr -v $BACKUP_ROOT:/backup busybox tar -xvf /backup/results_backup.tar /results
-    docker run --rm --volumes-from hint_hintr -v $BACKUP_ROOT:/backup busybox tar -xvf /backup/uploads_backup.tar /uploads
+restore() {
+    ABSOLUTE_PATH="$(
+        cd "$(dirname "$1")"
+        pwd
+    )/$(basename "$1")"
+    echo $1
+    echo $ABSOLUTE_PATH
+    docker run --rm --volumes-from hint_db -v $ABSOLUTE_PATH:/backup postgres psql -U postgres hint </backup/working/db_dump.sql
+    docker run --rm --volumes-from hint_redis -v $ABSOLUTE_PATH:/backup busybox tar -xvf /backup/redis_backup.tar /data
+    docker run --rm --volumes-from hint_hintr -v $ABSOLUTE_PATH:/backup busybox tar -xvf /backup/prerun_backup.tar /prerun
+    docker run --rm --volumes-from hint_hintr -v $ABSOLUTE_PATH:/backup busybox tar -xvf /backup/results_backup.tar /results
+    docker run --rm --volumes-from hint_hintr -v $ABSOLUTE_PATH:/backup busybox tar -xvf /backup/uploads_backup.tar /uploads
 }
 
 if [ check_all_data_exists ]; then

--- a/backup/restore
+++ b/backup/restore
@@ -79,6 +79,7 @@ clean_up() {
 trap clean_up ERR
 
 tar -xvf $1 -C $RESTORE_WORKING_DIR
+md5sum --check $RESTORE_WORKING_DIR/checklist.chk
 assert_all_data_exists $RESTORE_WORKING_DIR
 restore $RESTORE_WORKING_DIR
 echo "Restore complete"

--- a/backup/restore
+++ b/backup/restore
@@ -3,7 +3,10 @@
 ## Restore from a backup
 set -ex
 
-BACKUP_ROOT="$1"
+BACKUP_ROOT="$(
+    cd -- "$(dirname "$0")" >/dev/null 2>&1
+    pwd -P
+)"
 
 function check_all_data_exists {
     (-d "$1") && (-f "$1/pgdata_backup.tar") && (-f "$1/redis_backup.tar") &&

--- a/backup/restore
+++ b/backup/restore
@@ -67,7 +67,8 @@ wait_for_postgres() {
         #
         # seems heaps nicer but does not actually work properly
         # because it pulls us up to soon.
-        docker exec -i restore_pg psql -U postgres -d postgres -c "select 1;" >/dev/null 2>&1 && result=$?
+        result=0
+        docker exec -i restore_pg psql -U postgres -d postgres -c "select 1;" >/dev/null 2>&1 || result=$?
         if [[ $result -eq 0 ]]; then
             end_ts=$(date +%s)
             echo "postgres is available after $((end_ts - start_ts)) seconds"

--- a/backup/restore
+++ b/backup/restore
@@ -5,6 +5,23 @@ set -eE
 
 volumes=("hint_db_data" "hint_redis_data" "hint_prerun" "hint_results" "hint_uploads" "hint_config")
 
+assert_file_exists $1
+RESTORE_DIR="$(
+    cd "$(dirname "$1")"
+    pwd
+)"
+RESTORE_PATH=$RESTORE_DIR/$(basename "$1")
+RESTORE_WORKING_DIR=$RESTORE_DIR/working
+mkdir $RESTORE_WORKING_DIR
+clean_up() {
+    echo "Restore failed, cleaning up working dir"
+    rm -rf $RESTORE_WORKING_DIR
+    docker stop restore_pg || true
+    docker rm helper || true
+    exit 1
+}
+trap clean_up ERR
+
 array_contains() {
     local seeking=$1
     shift
@@ -49,10 +66,36 @@ create_volumes() {
     done
 }
 
+wait_for_postgres() {
+    echo "waiting 10 seconds for postgres"
+    start_ts=$(date +%s)
+    for i in $(seq 10); do
+        # Using pg_ready as:
+        #
+        #   pg_isready -U $POSTGRES_USER -d $POSTGRES_DB
+        #
+        # seems heaps nicer but does not actually work properly
+        # because it pulls us up to soon.
+        docker exec -i restore_pg psql -U postgres -d postgres -c "select 1;" >/dev/null 2>&1
+        result=$?
+        if [[ $result -eq 0 ]]; then
+            end_ts=$(date +%s)
+            echo "postgres is available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+        echo "...still waiting"
+    done
+    if [[ $result -ne 0 ]]; then
+        echo "Postgres did not become available in time"
+        clean_up
+    fi
+}
+
 restore() {
     create_volumes
     docker run --rm -d -v hint_db_data:/pgdata -e POSTGRES_PASSWORD=password -e PGDATA=/pgdata --name restore_pg postgres:10.3
-    sleep 5 ## Ideally here we would do something cleverer and poll for db being ready to accept connections
+    wait_for_postgres
     docker exec -i restore_pg psql -U postgres postgres <$1/db_dump.sql >/dev/null
     docker stop restore_pg
     docker run --rm -v hint_redis_data:/data -v $1:/backup busybox tar -xf /backup/redis_backup.tar -C /data
@@ -71,23 +114,6 @@ restore_key() {
     docker run --rm -v hint_config:/data busybox sh -c \
         "mkdir /data/token_key && echo $PUBLIC_KEY | base64 -d >/data/token_key/public_key.der && echo $PRIVATE_KEY | base64 -d >/data/token_key/private_key.der"
 }
-
-assert_file_exists $1
-RESTORE_DIR="$(
-    cd "$(dirname "$1")"
-    pwd
-)"
-RESTORE_PATH=$RESTORE_DIR/$(basename "$1")
-RESTORE_WORKING_DIR=$RESTORE_DIR/working
-mkdir $RESTORE_WORKING_DIR
-clean_up() {
-    echo "Restore failed, cleaning up working dir"
-    rm -rf $RESTORE_WORKING_DIR
-    docker stop restore_pg || true
-    docker rm helper || true
-    exit 1
-}
-trap clean_up ERR
 
 tar -xvf $1 -C $RESTORE_WORKING_DIR
 md5sum --check $RESTORE_WORKING_DIR/checklist.chk

--- a/backup/restore
+++ b/backup/restore
@@ -53,7 +53,7 @@ restore() {
     create_volumes
     docker run --rm -d -v hint_db_data:/pgdata -e POSTGRES_PASSWORD=password -e PGDATA=/pgdata --name restore_pg postgres:10.3
     sleep 5 ## Ideally here we would do something cleverer and poll for db being ready to accept connections
-    docker exec -i restore_pg psql -U postgres -d hint <$1/db_dump.sql
+    docker exec -i restore_pg psql -U postgres postgres <$1/db_dump.sql
     docker stop restore_pg
     docker run --rm -v hint_redis_data:/data -v $1:/backup busybox tar -xvf /backup/redis_backup.tar -C /data
     docker run --rm -v hint_prerun:/data -v $1:/backup busybox tar -xvf /backup/prerun_backup.tar -C /data

--- a/backup/restore
+++ b/backup/restore
@@ -67,8 +67,7 @@ wait_for_postgres() {
         #
         # seems heaps nicer but does not actually work properly
         # because it pulls us up to soon.
-        docker exec -i restore_pg psql -U postgres -d postgres -c "select 1;" >/dev/null 2>&1
-        result=$?
+        docker exec -i restore_pg psql -U postgres -d postgres -c "select 1;" >/dev/null 2>&1 || result=$?
         if [[ $result -eq 0 ]]; then
             end_ts=$(date +%s)
             echo "postgres is available after $((end_ts - start_ts)) seconds"

--- a/backup/restore
+++ b/backup/restore
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 ## Restore from a backup
-set -e
+set -eE
 
-volumes=("hint_db_data" "hint_redis_data" "hint_prerun" "hint_results" "hint_uploads", "hint_config")
+volumes=("hint_db_data" "hint_redis_data" "hint_prerun" "hint_results" "hint_uploads" "hint_config")
 
 array_contains() {
     local seeking=$1
@@ -83,8 +83,8 @@ mkdir $RESTORE_WORKING_DIR
 clean_up() {
     echo "Restore failed, cleaning up working dir"
     rm -rf $RESTORE_WORKING_DIR
-    docker stop restore_pg
-    docker rm helper
+    docker stop restore_pg || true
+    docker rm helper || true
     exit 1
 }
 trap clean_up ERR

--- a/backup/restore
+++ b/backup/restore
@@ -3,6 +3,7 @@
 ## Restore from a backup
 set -ex
 
+volumes=("hint_db_data", "hint_redis_data", "hint_prerun", "hint_results", "hint_uploads")
 assert_file_exists() {
     if !([ ! -z "$1" ] && [ -f "$1" ]); then
         echo "Backup dir $1 does not exist"
@@ -20,14 +21,31 @@ assert_all_data_exists() {
     fi
 }
 
+create_volumes() {
+    existing_volumes=$(docker volume ls --format '{{.Name}}')
+    for volume in ${volumes[@]}; do
+        if [[ " ${existing_volumes[*]} " =~ " ${volume} " ]]; then
+            echo "Volume ${volume} already exists, remove volume before running restore"
+            exit 1
+        fi
+    done
+    for volume in ${volumes[@]}; do
+        echo "Creating volume ${volume}"
+        docker volume create ${volume}
+    done
+}
+
 restore() {
-    docker exec hint_db dropdb -f hint
-    docker exec hint_db createdb -T template0 hint
+    create_volumes
+
     cat $1/db_dump.sql | docker exec -i hint_db psql -U postgres hint
-    docker run --rm --volumes-from hint_redis -v $1:/backup busybox tar -xvf /backup/redis_backup.tar.gz -C /data
-    docker run --rm --volumes-from hint_hintr -v $1:/backup busybox tar -xvf /backup/prerun_backup.tar.gz -C /prerun
-    docker run --rm --volumes-from hint_hintr -v $1:/backup busybox tar -xvf /backup/results_backup.tar.gz -C /results
-    docker run --rm --volumes-from hint_hintr -v $1:/backup busybox tar -xvf /backup/uploads_backup.tar.gz -C /uploads
+    docker run --rm -v hint_db_data:/data -v $1:/backup postgres:10.3 ### TODO
+    docker run --rm -v hint_redis_data:/data $1:/backup busybox tar -xvf /backup/redis_backup.tar -C /data
+    docker run --rm -v hint_prerun:/data -v $1:/backup busybox tar -xvf /backup/prerun_backup.tar -C /data
+    docker run --rm -v hint_results:/data -v $1:/backup busybox tar -xvf /backup/results_backup.tar -C /data
+    docker run --rm -v hint_uploads:/data -v $1:/backup busybox tar -xvf /backup/uploads_backup.tar -C /data
+    ## Restart everything with most up to date
+    ./hint upgrade all
 }
 
 assert_file_exists $1

--- a/backup/restore
+++ b/backup/restore
@@ -3,7 +3,7 @@
 ## Restore from a backup
 set -e
 
-volumes=("hint_db_data" "hint_redis_data" "hint_prerun" "hint_results" "hint_uploads")
+volumes=("hint_db_data" "hint_redis_data" "hint_prerun" "hint_results" "hint_uploads", "hint_config")
 
 array_contains() {
     local seeking=$1
@@ -61,6 +61,17 @@ restore() {
     docker run --rm -v hint_uploads:/data -v $1:/backup busybox tar -xvf /backup/uploads_backup.tar -C /data
 }
 
+restore_key() {
+    VAULT_PATH=$(cat $RESTORE_WORKING_DIR/cipher_path)
+    echo "Restoring keys from vault path '$VAULT_PATH'"
+    VAULT_ADDR="https://vault.dide.ic.ac.uk:8200"
+    vault login -address=$VAULT_ADDR -method=github
+    PUBLIC_KEY=$(vault read -field=public $VAULT_PATH | base64 --decode --ignore-garbage)
+    PRIVATE_KEY=$(vault read -field=private $VAULT_PATH | base64 --decode --ignore-garbage)
+    docker run --rm -v hint_config:/data busybox sh -c \
+        "mkdir /data/token_key && echo $PUBLIC_KEY >/data/token_key/public_key.der && echo $PRIVATE_KEY >/data/token_key/private_key.der"
+}
+
 assert_file_exists $1
 RESTORE_DIR="$(
     cd "$(dirname "$1")"
@@ -82,5 +93,14 @@ tar -xvf $1 -C $RESTORE_WORKING_DIR
 md5sum --check $RESTORE_WORKING_DIR/checklist.chk
 assert_all_data_exists $RESTORE_WORKING_DIR
 restore $RESTORE_WORKING_DIR
+if [ -f "$RESTORE_WORKING_DIR/cipher_path" ]; then
+    echo "Do you want to restore cipher keys from vault?"
+    read -p "Restore keys? y/n" -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        restore_key
+    fi
+fi
+
 echo "Restore complete"
 rm -rf $RESTORE_WORKING_DIR

--- a/backup/restore
+++ b/backup/restore
@@ -27,7 +27,7 @@ assert_file_exists() {
 }
 
 assert_all_data_exists() {
-    if !([ ! -z "$1" ] && [ -d "$1" ] && [ -f "$1/db_dump.sql" ] && [ -f "$1/dump.rdb" ] &&
+    if !([ ! -z "$1" ] && [ -d "$1" ] && [ -f "$1/db_dump.sql" ] && [ -f "$1/redis_backup.tar" ] &&
         [ -f "$1/prerun_backup.tar" ] && [ -f "$1/results_backup.tar" ] && [ -f "$1/uploads_backup.tar" ]); then
         echo "Backup dir $1 is incomplete"
         echo "Usage: restore <backup_dir>"
@@ -52,13 +52,10 @@ create_volumes() {
 restore() {
     create_volumes
     docker run --rm -d -v hint_db_data:/pgdata -e POSTGRES_PASSWORD=password -e PGDATA=/pgdata --name restore_pg postgres:10.3
-    sleep 10 ## Ideally here we would do something cleverer and poll for db being ready to accept connections
-    docker exec -i restore_pg createdb -U postgres hint
+    sleep 5 ## Ideally here we would do something cleverer and poll for db being ready to accept connections
     docker exec -i restore_pg psql -U postgres -d hint <$1/db_dump.sql
     docker stop restore_pg
-    docker run -v hint_redis_data:/data --name helper busybox true
-    docker cp $1/dump.rdb helper:/data
-    docker rm helper
+    docker run --rm -v hint_redis_data:/data -v $1:/backup busybox tar -xvf /backup/redis_backup.tar -C /data
     docker run --rm -v hint_prerun:/data -v $1:/backup busybox tar -xvf /backup/prerun_backup.tar -C /data
     docker run --rm -v hint_results:/data -v $1:/backup busybox tar -xvf /backup/results_backup.tar -C /data
     docker run --rm -v hint_uploads:/data -v $1:/backup busybox tar -xvf /backup/uploads_backup.tar -C /data

--- a/backup/restore
+++ b/backup/restore
@@ -27,7 +27,7 @@ assert_file_exists() {
 }
 
 assert_all_data_exists() {
-    if !([ ! -z "$1" ] && [ -d "$1" ] && [ -f "$1/db_dump.sql" ] && [ -f "$1/redis_backup.tar" ] &&
+    if !([ ! -z "$1" ] && [ -d "$1" ] && [ -f "$1/db_dump.sql" ] && [ -f "$1/dump.rdb" ] &&
         [ -f "$1/prerun_backup.tar" ] && [ -f "$1/results_backup.tar" ] && [ -f "$1/uploads_backup.tar" ]); then
         echo "Backup dir $1 is incomplete"
         echo "Usage: restore <backup_dir>"
@@ -52,7 +52,10 @@ create_volumes() {
 restore() {
     create_volumes
     docker run --rm -v hint_db_data:/pgdata -v $1:/backup postgres:10-alpine -c "cat /backup/db_dump.sql | psql -U postgres hint"
-    docker run --rm -v hint_redis_data:/data $1:/backup busybox tar -xvf /backup/redis_backup.tar -C /data
+    docker run -v hint_redis_data:/ --name helper busybox true
+    docker cp $1/dump.rdb helper:/
+    docker rm helper
+    docker cp run --rm -v hint_redis_data:/data $1:/backup redis:5.0
     docker run --rm -v hint_prerun:/data -v $1:/backup busybox tar -xvf /backup/prerun_backup.tar -C /data
     docker run --rm -v hint_results:/data -v $1:/backup busybox tar -xvf /backup/results_backup.tar -C /data
     docker run --rm -v hint_uploads:/data -v $1:/backup busybox tar -xvf /backup/uploads_backup.tar -C /data

--- a/backup/restore
+++ b/backup/restore
@@ -3,14 +3,9 @@
 ## Restore from a backup
 set -ex
 
-BACKUP_ROOT="$(
-    cd -- "$(dirname "$0")" >/dev/null 2>&1
-    pwd -P
-)"
-
-function check_all_data_exists {
-    (-d "$1") && (-f "$1/pgdata_backup.tar") && (-f "$1/redis_backup.tar") &&
-        (-f "$1/prerun_backup.tar") && (-f "$1/results_backup.tar") && (-f "$1/uploads_backup.tar")
+check_all_data_exists() {
+    [ ! -z "$1" ] && [ -d "$1" ] && [ -f "$1/pgdata_backup.tar" ] && [ -f "$1/redis_backup.tar" ] &&
+        [ -f "$1/prerun_backup.tar" ] && [ -f "$1/results_backup.tar" ] && [ -f "$1/uploads_backup.tar" ]
 }
 
 restore() {
@@ -27,10 +22,10 @@ restore() {
     docker run --rm --volumes-from hint_hintr -v $ABSOLUTE_PATH:/backup busybox tar -xvf /backup/uploads_backup.tar /uploads
 }
 
-if [ check_all_data_exists ]; then
-    restore
+if check_all_data_exists $1; then
+    restore $1
 else
-    echo "Backup $1 does not exist or is incomplete"
+    echo "Backup dir $1 does not exist or is incomplete"
     echo "Usage: restore <backup_dir>"
     exit 1
 fi

--- a/backup/restore
+++ b/backup/restore
@@ -67,7 +67,7 @@ wait_for_postgres() {
         #
         # seems heaps nicer but does not actually work properly
         # because it pulls us up to soon.
-        docker exec -i restore_pg psql -U postgres -d postgres -c "select 1;" >/dev/null 2>&1 || result=$?
+        docker exec -i restore_pg psql -U postgres -d postgres -c "select 1;" >/dev/null 2>&1 && result=$?
         if [[ $result -eq 0 ]]; then
             end_ts=$(date +%s)
             echo "postgres is available after $((end_ts - start_ts)) seconds"

--- a/backup/restore
+++ b/backup/restore
@@ -1,9 +1,23 @@
 #!/usr/bin/env bash
 
 ## Restore from a backup
-set -ex
+set -e
 
-volumes=("hint_db_data", "hint_redis_data", "hint_prerun", "hint_results", "hint_uploads")
+volumes=("hint_db_data" "hint_redis_data" "hint_prerun" "hint_results" "hint_uploads")
+
+array_contains() {
+    local seeking=$1
+    shift
+    local in=1
+    for element; do
+        if [[ $element == "$seeking" ]]; then
+            in=0
+            break
+        fi
+    done
+    return $in
+}
+
 assert_file_exists() {
     if !([ ! -z "$1" ] && [ -f "$1" ]); then
         echo "Backup dir $1 does not exist"
@@ -13,8 +27,8 @@ assert_file_exists() {
 }
 
 assert_all_data_exists() {
-    if !([ ! -z "$1" ] && [ -d "$1" ] && [ -f "$1/db_dump.sql" ] && [ -f "$1/redis_backup.tar.gz" ] &&
-        [ -f "$1/prerun_backup.tar.gz" ] && [ -f "$1/results_backup.tar.gz" ] && [ -f "$1/uploads_backup.tar.gz" ]); then
+    if !([ ! -z "$1" ] && [ -d "$1" ] && [ -f "$1/db_dump.sql" ] && [ -f "$1/redis_backup.tar" ] &&
+        [ -f "$1/prerun_backup.tar" ] && [ -f "$1/results_backup.tar" ] && [ -f "$1/uploads_backup.tar" ]); then
         echo "Backup dir $1 is incomplete"
         echo "Usage: restore <backup_dir>"
         exit 1
@@ -22,10 +36,10 @@ assert_all_data_exists() {
 }
 
 create_volumes() {
-    existing_volumes=$(docker volume ls --format '{{.Name}}')
+    existing_volumes=($(docker volume ls --format '{{.Name}}'))
     for volume in ${volumes[@]}; do
-        if [[ " ${existing_volumes[*]} " =~ " ${volume} " ]]; then
-            echo "Volume ${volume} already exists, remove volume before running restore"
+        if array_contains "$volume" "${existing_volumes[@]}"; then
+            echo "Volume '${volume}' already exists, remove volume before running restore"
             exit 1
         fi
     done
@@ -42,8 +56,6 @@ restore() {
     docker run --rm -v hint_prerun:/data -v $1:/backup busybox tar -xvf /backup/prerun_backup.tar -C /data
     docker run --rm -v hint_results:/data -v $1:/backup busybox tar -xvf /backup/results_backup.tar -C /data
     docker run --rm -v hint_uploads:/data -v $1:/backup busybox tar -xvf /backup/uploads_backup.tar -C /data
-    ## Restart everything with most up to date
-    ./hint upgrade all
 }
 
 assert_file_exists $1

--- a/backup/restore
+++ b/backup/restore
@@ -20,8 +20,8 @@ array_contains() {
 
 assert_file_exists() {
     if !([ ! -z "$1" ] && [ -f "$1" ]); then
-        echo "Backup dir $1 does not exist"
-        echo "Usage: restore <backup_dir>"
+        echo "Backup archive $1 does not exist"
+        echo "Usage: restore <backup_file>"
         exit 1
     fi
 }
@@ -29,8 +29,8 @@ assert_file_exists() {
 assert_all_data_exists() {
     if !([ ! -z "$1" ] && [ -d "$1" ] && [ -f "$1/db_dump.sql" ] && [ -f "$1/redis_backup.tar" ] &&
         [ -f "$1/prerun_backup.tar" ] && [ -f "$1/results_backup.tar" ] && [ -f "$1/uploads_backup.tar" ]); then
-        echo "Backup dir $1 is incomplete"
-        echo "Usage: restore <backup_dir>"
+        echo "Backup archive $1 is incomplete"
+        echo "Usage: restore <backup_file>"
         exit 1
     fi
 }

--- a/backup/restore
+++ b/backup/restore
@@ -37,9 +37,7 @@ create_volumes() {
 
 restore() {
     create_volumes
-
-    cat $1/db_dump.sql | docker exec -i hint_db psql -U postgres hint
-    docker run --rm -v hint_db_data:/data -v $1:/backup postgres:10.3 ### TODO
+    docker run --rm -v hint_db_data:/pgdata -v $1:/backup postgres:10-alpine -c "cat /backup/db_dump.sql | psql -U postgres hint"
     docker run --rm -v hint_redis_data:/data $1:/backup busybox tar -xvf /backup/redis_backup.tar -C /data
     docker run --rm -v hint_prerun:/data -v $1:/backup busybox tar -xvf /backup/prerun_backup.tar -C /data
     docker run --rm -v hint_results:/data -v $1:/backup busybox tar -xvf /backup/results_backup.tar -C /data

--- a/backup/restore
+++ b/backup/restore
@@ -3,29 +3,41 @@
 ## Restore from a backup
 set -ex
 
-check_all_data_exists() {
-    [ ! -z "$1" ] && [ -d "$1" ] && [ -f "$1/pgdata_backup.tar" ] && [ -f "$1/redis_backup.tar" ] &&
-        [ -f "$1/prerun_backup.tar" ] && [ -f "$1/results_backup.tar" ] && [ -f "$1/uploads_backup.tar" ]
+assert_file_exists() {
+    if !([ ! -z "$1" ] && [ -f "$1" ]); then
+        echo "Backup dir $1 does not exist"
+        echo "Usage: restore <backup_dir>"
+        exit 1
+    fi
+}
+
+assert_all_data_exists() {
+    if !([ ! -z "$1" ] && [ -d "$1" ] && [ -f "$1/pgdata_backup.tar" ] && [ -f "$1/redis_backup.tar" ] &&
+        [ -f "$1/prerun_backup.tar" ] && [ -f "$1/results_backup.tar" ] && [ -f "$1/uploads_backup.tar" ]); then
+        echo "Backup dir $1 is incomplete"
+        echo "Usage: restore <backup_dir>"
+        exit 1
+    fi
+}
+
+unzip() {
+    tar -xvf $1 -C $2
 }
 
 restore() {
-    ABSOLUTE_PATH="$(
-        cd "$(dirname "$1")"
-        pwd
-    )/$(basename "$1")"
-    echo $1
-    echo $ABSOLUTE_PATH
-    docker run --rm --volumes-from hint_db -v $ABSOLUTE_PATH:/backup postgres psql -U postgres hint </backup/working/db_dump.sql
-    docker run --rm --volumes-from hint_redis -v $ABSOLUTE_PATH:/backup busybox tar -xvf /backup/redis_backup.tar /data
-    docker run --rm --volumes-from hint_hintr -v $ABSOLUTE_PATH:/backup busybox tar -xvf /backup/prerun_backup.tar /prerun
-    docker run --rm --volumes-from hint_hintr -v $ABSOLUTE_PATH:/backup busybox tar -xvf /backup/results_backup.tar /results
-    docker run --rm --volumes-from hint_hintr -v $ABSOLUTE_PATH:/backup busybox tar -xvf /backup/uploads_backup.tar /uploads
+    docker exec hint_db psql -U postgres hint <$1/db_dump.sql
+    docker run --rm --volumes-from hint_redis -v $1:/backup busybox tar -xvf /backup/redis_backup.tar /data
+    docker run --rm --volumes-from hint_hintr -v $1:/backup busybox tar -xvf /backup/prerun_backup.tar /prerun
+    docker run --rm --volumes-from hint_hintr -v $1:/backup busybox tar -xvf /backup/results_backup.tar /results
+    docker run --rm --volumes-from hint_hintr -v $1:/backup busybox tar -xvf /backup/uploads_backup.tar /uploads
 }
 
-if check_all_data_exists $1; then
-    restore $1
-else
-    echo "Backup dir $1 does not exist or is incomplete"
-    echo "Usage: restore <backup_dir>"
-    exit 1
-fi
+ABSOLUTE_PATH="$(
+    cd "$(dirname "$1")"
+    pwd
+)/$(basename "$1")"
+WORKING_DIR=$ABSOLUTE_PATH/working
+assert_file_exists $1
+unzip $1 $WORKING_DIR
+assert_all_data_exists $WORKING_DIR
+restore $WORKING_DIR

--- a/backup/restore
+++ b/backup/restore
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+## Restore from a backup
+set -ex
+
+BACKUP_ROOT="$1"
+
+function check_all_data_exists {
+    (-d "$1") && (-f "$1/pgdata_backup.tar") && (-f "$1/redis_backup.tar") &&
+        (-f "$1/prerun_backup.tar") && (-f "$1/results_backup.tar") && (-f "$1/uploads_backup.tar")
+}
+
+function restore {
+    docker run --rm --volumes-from hint_db -v $BACKUP_ROOT:/backup busybox tar -xvf /backup/pgdata_backup.tar /pgdata
+    docker run --rm --volumes-from hint_redis -v $BACKUP_ROOT:/backup busybox tar -xvf /backup/redis_backup.tar /data
+    docker run --rm --volumes-from hint_hintr -v $BACKUP_ROOT:/backup busybox tar -xvf /backup/prerun_backup.tar /prerun
+    docker run --rm --volumes-from hint_hintr -v $BACKUP_ROOT:/backup busybox tar -xvf /backup/results_backup.tar /results
+    docker run --rm --volumes-from hint_hintr -v $BACKUP_ROOT:/backup busybox tar -xvf /backup/uploads_backup.tar /uploads
+}
+
+if [ check_all_data_exists ]; then
+    restore
+else
+    echo "Backup $1 does not exist or is incomplete"
+    echo "Usage: restore <backup_dir>"
+    exit 1
+fi

--- a/backup/restore
+++ b/backup/restore
@@ -21,7 +21,9 @@ assert_all_data_exists() {
 }
 
 restore() {
-    docker exec hint_db psql -U postgres hint <$1/db_dump.sql
+    docker exec hint_db psql -U postgres -c "DROP DATABASE hint"
+    docker exec hint_db psql -U postgres -c "CREATE DATABASE hint"
+    cat $1/db_dump.sql | docker exec -i hint_db psql -U postgres hint
     docker run --rm --volumes-from hint_redis -v $1:/backup busybox tar -xvf /backup/redis_backup.tar.gz -C /data
     docker run --rm --volumes-from hint_hintr -v $1:/backup busybox tar -xvf /backup/prerun_backup.tar.gz -C /prerun
     docker run --rm --volumes-from hint_hintr -v $1:/backup busybox tar -xvf /backup/results_backup.tar.gz -C /results


### PR DESCRIPTION
This PR will add script to save snapshot of db, redis and uploaded files into tar archive and a script to then restore this state in on a new system. We need this because we want to move the production deployment onto the new server, but we could adapt it in future for storing a backup of the whole system state.

Note also we optionally save out a private a public key from the backup into the vault and then read this in in the restore. This is necessary because we store ADR keys encrypted and this is the keypair used to enable that encryption and decryption. If we want users to be able to use ADR keys entered on the old prod machine on the new prod machine then we need to migrate these over. This is done using the vault.

To test this
* ssh onto hint-dev and run `./backup/backup`
* ssh onto workstation and run (using the name of the created backup file)
```
rsync -az hiv-naomi-dev:/home/vagrant/hint-deploy/backup/2022_01_07-16_06_12.tar.gz .
rsync -az 2022_01_07-16_06_12.tar.gz hiv-naomi:/home/vagrant/hint-deploy/backup/.
```
* ssh onto new machine and run `./backup/restore ./backup/2022_01_07-16_06_12.tar.gz`
* Run the app, `./hint start production_new`