### PR TITLE
mrc-3569 Remove handling of validation from hint-deploy

### DIFF
--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -206,10 +206,6 @@ def hint_user(cfg, action, email, pull, password=None):
         docker_util.image_pull("hint cli", str(ref))
     args = [action, email]
     if action == "add-user":
-        res_exists = hint_user_run(ref, ["user-exists", email], cfg)
-        if res_exists.endswith("\ntrue"):
-            print("Not adding user {} as they already exist".format(email))
-            return
         if password:
             args.append(password)
     hint_user_run(ref, args, cfg)


### PR DESCRIPTION
This PR removes duplicate validation, checking if user exists before adding. addUser already checks if user exists and throws exception if it does. 

Pac4j now performs jsonSerialisation on userProfile, failed attempt to add `test.user@example.com` via hint-deploy affected pac4j profile attributes, which causes pac4j deserialisation to fail as it wasn't able to serialise. This issue caused login failure for only "test.user@example.com" as the profile got corrupted. We weren't affected by this issue when using pac4j 3.6 because profile serialisation got introduced since pac4j-5.0 but since we upgraded to pac4j-5.4 hence this glitch.


This PR moves handling of validation to userCLI


I am requesting @richfitz and @EmmaLRussell , if any of you can fix the test. Thanks.
