### PR TITLE
Add ADR URL and audience to config properties

### DIFF
--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -279,7 +279,9 @@ def hint_configure(container, cfg):
         "issue_report_url": cfg.hint_issue_report_url,
         "oauth2_client_id": cfg.hint_oauth2_client_id,
         "oauth2_client_secret": cfg.hint_oauth2_client_secret,
-        "oauth2_client_url": cfg.hint_oauth2_client_url
+        "oauth2_client_url": cfg.hint_oauth2_client_url,
+        "oauth2_client_adr_url": cfg.hint_oauth2_client_adr_url,
+        "oauth2_client_audience ": cfg.hint_oauth2_client_audience
     }
 
     if cfg.hint_adr_url is not None:


### PR DESCRIPTION
We added this in #54 but forgot to put them into the config.properties