### PR TITLE
mrc-3603: Migrate serializedprofile column to JSON serialization

### DIFF
--- a/scripts/fix_profile_encoding.groovy
+++ b/scripts/fix_profile_encoding.groovy
@@ -1,36 +1,11 @@
 @GrabConfig(systemClassLoader=true)
 @Grab(group='org.postgresql', module='postgresql',  version='9.4-1205-jdbc42')
-@Grab(group='org.pac4j', module='pac4j-core', version='3.3.0')
-@Grab(group='org.pac4j', module='pac4j-sql', version='3.3.0')
-@Grab(group='com.fasterxml.jackson.core', module='jackson-core', version='2.13.4')
-@Grab(group='com.fasterxml.jackson.core', module='jackson-annotations', version='2.13.4')
-@Grab(group='com.fasterxml.jackson.core', module='jackson-databind', version='2.13.4')
+@Grab(group='org.pac4j', module='pac4j-core', version='3.9.0')
+@Grab(group='org.pac4j', module='pac4j-sql', version='3.9.0')
 @Grab(group='ch.qos.logback', module='logback-classic', version='1.0.13')
 import groovy.sql.Sql
 import org.pac4j.sql.profile.DbProfile
-import org.pac4j.core.util.JavaSerializationHelper
-import com.fasterxml.jackson.annotation.JsonAutoDetect
-import com.fasterxml.jackson.annotation.PropertyAccessor
-import com.fasterxml.jackson.core.JsonProcessingException
-import com.fasterxml.jackson.databind.ObjectMapper
-
-public class JsonSerializer {
-
-    private ObjectMapper objectMapper
-
-    public JsonSerializer() {
-        objectMapper = new ObjectMapper();
-        objectMapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
-        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
-    }
-
-    public String encode(final Object obj) {
-        if (obj == null) {
-            return null;
-        }
-        return objectMapper.writeValueAsString(obj);
-    }
-}
+import org.pac4j.core.util.serializer.ProfileServiceSerializer
 
 class Profile {
     String id;
@@ -42,13 +17,13 @@ class Profile {
         this.serializedProfile = serializedProfile
     }
 
-    void recode(JavaSerializationHelper helper, JsonSerializer serializer) {
+    void recode(ProfileServiceSerializer serializer) {
         println this.serializedProfile
         if (this.serializedProfile.startsWith("{")) {
-            println "Profile already in JSON format"
+            println "Not migrating as already in JSON format"
             return
         }
-        DbProfile decoded = helper.unserializeFromBase64(this.serializedProfile)
+        DbProfile decoded = serializer.decode(this.serializedProfile)
         this.serializedProfile = serializer.encode(decoded)
         println "Migrated to JSON format"
         println this.serializedProfile
@@ -67,12 +42,11 @@ con.eachRow("SELECT id, serializedprofile from users;") { row ->
     profiles << new Profile(row.id, row.serializedprofile)
 }
 
-JavaSerializationHelper helper = new JavaSerializationHelper()
-JsonSerializer serializer = new JsonSerializer()
+ProfileServiceSerializer serializer = new ProfileServiceSerializer(DbProfile.class)
 def updateSql = "UPDATE users SET serializedprofile = ? where id = ?"
 con.withTransaction {
     profiles.each { profile ->
-        profile.recode(helper, serializer)
+        profile.recode(serializer)
         if (profile.updated) {
             con.execute updateSql, [profile.serializedProfile, profile.id]
         }

--- a/scripts/fix_profile_encoding.groovy
+++ b/scripts/fix_profile_encoding.groovy
@@ -1,12 +1,81 @@
-import groovy.sql.Sql 
+@GrabConfig(systemClassLoader=true)
+@Grab(group='org.postgresql', module='postgresql',  version='9.4-1205-jdbc42')
+@Grab(group='org.pac4j', module='pac4j-core', version='3.3.0')
+@Grab(group='org.pac4j', module='pac4j-sql', version='3.3.0')
+@Grab(group='com.fasterxml.jackson.core', module='jackson-core', version='2.13.4')
+@Grab(group='com.fasterxml.jackson.core', module='jackson-annotations', version='2.13.4')
+@Grab(group='com.fasterxml.jackson.core', module='jackson-databind', version='2.13.4')
+@Grab(group='ch.qos.logback', module='logback-classic', version='1.0.13')
+import groovy.sql.Sql
+import org.pac4j.sql.profile.DbProfile
+import org.pac4j.core.util.JavaSerializationHelper
+import com.fasterxml.jackson.annotation.JsonAutoDetect
+import com.fasterxml.jackson.annotation.PropertyAccessor
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
 
-println "Hello World"
+public class JsonSerializer {
+
+    private ObjectMapper objectMapper
+
+    public JsonSerializer() {
+        objectMapper = new ObjectMapper();
+        objectMapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
+        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+    }
+
+    public String encode(final Object obj) {
+        if (obj == null) {
+            return null;
+        }
+        return objectMapper.writeValueAsString(obj);
+    }
+}
+
+class Profile {
+    String id;
+    String serializedProfile;
+    boolean updated = false;
+
+    Profile(id, serializedProfile) {
+        this.id = id
+        this.serializedProfile = serializedProfile
+    }
+
+    void recode(JavaSerializationHelper helper, JsonSerializer serializer) {
+        println this.serializedProfile
+        if (this.serializedProfile.startsWith("{")) {
+            println "Profile already in JSON format"
+            return
+        }
+        DbProfile decoded = helper.unserializeFromBase64(this.serializedProfile)
+        this.serializedProfile = serializer.encode(decoded)
+        println "Migrated to JSON format"
+        println this.serializedProfile
+        this.updated = true;
+    }
+}
 
 def dbUrl      = "jdbc:postgresql://hint_db/hint"
-def dbUser     = "postgres"
-def dbPassword = "password"
+def dbUser     = "hintuser"
+def dbPassword = "changeme"
 def dbDriver   = "org.postgresql.Driver"
-
 def con = Sql.newInstance(dbUrl, dbUser, dbPassword, dbDriver)
 
-println con.execute("SELECT count(*) from users")
+def profiles = []
+con.eachRow("SELECT id, serializedprofile from users;") { row ->
+    profiles << new Profile(row.id, row.serializedprofile)
+}
+
+JavaSerializationHelper helper = new JavaSerializationHelper()
+JsonSerializer serializer = new JsonSerializer()
+def updateSql = "UPDATE users SET serializedprofile = ? where id = ?"
+con.withTransaction {
+    profiles.each { profile ->
+        profile.recode(helper, serializer)
+        if (profile.updated) {
+            con.execute updateSql, [profile.serializedProfile, profile.id]
+        }
+    }
+}
+

--- a/scripts/fix_profile_encoding.groovy
+++ b/scripts/fix_profile_encoding.groovy
@@ -1,0 +1,12 @@
+import groovy.sql.Sql 
+
+println "Hello World"
+
+def dbUrl      = "jdbc:postgresql://hint_db/hint"
+def dbUser     = "postgres"
+def dbPassword = "password"
+def dbDriver   = "org.postgresql.Driver"
+
+def con = Sql.newInstance(dbUrl, dbUser, dbPassword, dbDriver)
+
+println con.execute("SELECT count(*) from users")

--- a/scripts/run_fix_profile_encoding.sh
+++ b/scripts/run_fix_profile_encoding.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -ex
+
+docker run --rm -v "$PWD":/home/groovy/scripts --network=hint_nw -w /home/groovy/scripts groovy:4.0.4-jdk11-alpine groovy fix_profile_encoding.groovy


### PR DESCRIPTION
I'm not expecting this to be merged this is a 1 off script and I am just putting it here as a reference. I can move this to somewhere else if there is somewhere more appropriate.

We recently updated from pac4j 3.3.0 to 5.4.3 see https://github.com/mrc-ide/hint/pull/731/files

This update includes some changes to format for the serialised user profile in the database see https://github.com/pac4j/pac4j/blob/master/documentation/blog/what_s_new_in_pac4j_v5.md#b-serializedprofile

In particular 3.3.0 was using Java serialization and now pac4j uses JSON. This was resulting in errors on our end when trying to login as test.user on staging and preview (see ticket for errors). We wiped the volumes on dev deployment so the test.user there has serializedprofile in the new format. We can't just wipe volume on prod so we need to migrate to the new format as this will affect all existing users.

The uses https://github.com/pac4j/pac4j/blob/a1ae387ce42b09ffa114065f8782061404be4cf4/pac4j-core/src/main/java/org/pac4j/core/util/serializer/ProfileServiceSerializer.java to decode serialized profiles and recode them in JSON format.

Process for running on prod
1. Make a backup `./backup/backup`
2. Checkout this branch of hint-deploy
3. Run the migration `cd scripts & ./scripts/run_fix_profile_encoding.sh`
4. Check login now works and switch back to master branch of hint-deploy

I have run this on staging, if you want to you can restore staging from the backup and re-run this to see it working.

One question:
In the old version of pac4j `canAttributesBeMerged` was FALSE see https://github.com/pac4j/pac4j/blob/pac4j-3.9.0/pac4j-core/src/main/java/org/pac4j/core/profile/UserProfile.java#L48
But in new pac4j `canAttributesBeMerged` is TRUE see https://github.com/pac4j/pac4j/blob/master/pac4j-core/src/main/java/org/pac4j/core/profile/BasicUserProfile.java#L48

So after the migration, newly added accounts have `canAttributesBeMerged` true, whilst the migrated ones have `canAttributesBeMerged` false. Is this ok? Should I update the old ones during the migration to set this to true?