### PR TITLE
add login method to deployment config

### DIFF
--- a/config/dev.yml
+++ b/config/dev.yml
@@ -15,11 +15,11 @@ vault:
       secret_id: $VAULT_AUTH_SECRET_ID
 
 hint:
+  oauth2_login_method: true
   issue_report_url: VAULT:secret/hint/flow-webhooks/issue-report:url
   oauth2_client_id: VAULT:secret/hint/oauth2/auth0:id
   oauth2_client_secret: VAULT:secret/hint/oauth2/auth0:secret
   oauth2_client_url: VAULT:secret/hint/oauth2/auth0:url
-  oauth2_login_method: true
   email:
     password: VAULT:secret/hint/email:password
 

--- a/config/dev.yml
+++ b/config/dev.yml
@@ -19,6 +19,7 @@ hint:
   oauth2_client_id: VAULT:secret/hint/oauth2/auth0:id
   oauth2_client_secret: VAULT:secret/hint/oauth2/auth0:secret
   oauth2_client_url: VAULT:secret/hint/oauth2/auth0:url
+  oauth2_login_method: true
   email:
     password: VAULT:secret/hint/email:password
 

--- a/config/preview.yml
+++ b/config/preview.yml
@@ -19,5 +19,6 @@ hint:
   oauth2_client_id: VAULT:secret/hint/oauth2/auth0:id
   oauth2_client_secret: VAULT:secret/hint/oauth2/auth0:secret
   oauth2_client_url: VAULT:secret/hint/oauth2/auth0:url
+  oauth2_login_method: false
   email:
     password: VAULT:secret/hint/email:password

--- a/config/production.yml
+++ b/config/production.yml
@@ -1,6 +1,7 @@
 hint:
   adr_url: https://adr.unaids.org/
   issue_report_url: VAULT:secret/hint/flow-webhooks/issue-report:url
+  oauth2_login_method: false
   email:
     password: VAULT:secret/hint/email:password
 

--- a/config/production_new.yml
+++ b/config/production_new.yml
@@ -1,6 +1,7 @@
 hint:
   adr_url: https://adr.unaids.org/
   issue_report_url: VAULT:secret/hint/flow-webhooks/issue-report:url
+  oauth2_login_method: false
   email:
     password: VAULT:secret/hint/email:password
 

--- a/config/staging.yml
+++ b/config/staging.yml
@@ -19,5 +19,6 @@ hint:
   oauth2_client_id: VAULT:secret/hint/oauth2/auth0:id
   oauth2_client_secret: VAULT:secret/hint/oauth2/auth0:secret
   oauth2_client_url: VAULT:secret/hint/oauth2/auth0:url
+  oauth2_login_method: false
   email:
     password: VAULT:secret/hint/email:password

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -53,8 +53,8 @@ class HintConfig:
         self.hint_oauth2_client_url = config.config_string(
             dat, ["hint", "oauth2_client_url"], True, "")
 
-        self.hint_oauth2_login_method = config.config_string(
-            dat, ["hint", "oauth2_login_method"], True, "")
+        self.hint_oauth2_login_method = config.config_boolean(
+            dat, ["hint", "oauth2_login_method"], True, False)
 
         self.hint_oauth2_client_adr_url = config.config_string(
             dat, ["hint", "oauth2_client_adr_url"], True, "")

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -53,6 +53,9 @@ class HintConfig:
         self.hint_oauth2_client_url = config.config_string(
             dat, ["hint", "oauth2_client_url"], True, "")
 
+        self.hint_oauth2_login_method = config.config_string(
+            dat, ["hint", "oauth2_login_method"], True, "")
+
         self.hint_email_mode = "real" if self.hint_email_password else "disk"
         self.hint_adr_url = config.config_string(
             dat, ["hint", "adr_url"], True)
@@ -273,7 +276,8 @@ def hint_configure(container, cfg):
         "issue_report_url": cfg.hint_issue_report_url,
         "oauth2_client_id": cfg.hint_oauth2_client_id,
         "oauth2_client_secret": cfg.hint_oauth2_client_secret,
-        "oauth2_client_url": cfg.hint_oauth2_client_url
+        "oauth2_client_url": cfg.hint_oauth2_client_url,
+        "oauth2_login_method": cfg.hint_oauth2_login_method
     }
 
     if cfg.hint_adr_url is not None:


### PR DESCRIPTION
This PR updates deployment config. Login method flag can be specified to use within 0Auth2 or not. 