### PR TITLE
Fix remote backup

### DIFF
--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine
+
+RUN apt-get update && apt-get -y install --no-install-recommends \
+    openssh \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+CMD [ "bash" ]

--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -1,8 +1,5 @@
 FROM alpine
 
-RUN apt-get update && apt-get -y install --no-install-recommends \
-    openssh \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache openssh
 
-CMD [ "bash" ]
+CMD [ "sh" ]

--- a/backup/backup
+++ b/backup/backup
@@ -9,7 +9,7 @@ SCRIPT_DIR="$(
     pwd -P
 )"
 NOW=$(date +'%Y_%d_%m-%H_%M_%S')
-BACKUP_PATH="$SCRIPT_DIR/$NOW.tar"
+BACKUP_PATH="$SCRIPT_DIR/$HOSTNAME_$NOW.tar"
 BACKUP_WORKING_DIR="$SCRIPT_DIR/working"
 mkdir $BACKUP_WORKING_DIR
 

--- a/backup/backup_remote
+++ b/backup/backup_remote
@@ -54,7 +54,7 @@ if ! $(ssh $SERVER "[ -d $BACKUP_DIR ]"); then
 fi
 
 NOW=$(date +'%Y_%d_%m-%H_%M_%S')
-BACKUP_PATH="$BACKUP_DIR/$NOW.tar"
+BACKUP_PATH="$BACKUP_DIR/$HOSTNAME_$NOW.tar"
 BACKUP_WORKING_DIR="$BACKUP_DIR/working"
 ssh $SERVER "mkdir $BACKUP_WORKING_DIR"
 

--- a/backup/backup_remote
+++ b/backup/backup_remote
@@ -76,9 +76,12 @@ echo "another server and have the user entered ADR keys still work then you need
 read -p "Backup keys? y/n" -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]; then
-    RESTORE_KEY=true
-else
-    RESTORE_KEY=false
+    vault login -address=$VAULT_ADDR -method=github
+    PUBLIC_KEY=$(docker run --rm --volumes-from hint_hint busybox cat /etc/hint/token_key/public_key.der | base64 --wrap=0)
+    PRIVATE_KEY=$(docker run --rm --volumes-from hint_hint busybox cat /etc/hint/token_key/private_key.der | base64 --wrap=0)
+    echo "Writing private and public keys to $VAULT_PATH"
+    vault write -address=$VAULT_ADDR $VAULT_PATH public=$PUBLIC_KEY private=$PRIVATE_KEY
+    echo "$VAULT_PATH" | ssh $SERVER "cat > $BACKUP_WORKING_DIR/cipher_path"
 fi
 
 echo "Building backup container"
@@ -122,15 +125,6 @@ docker run --rm \
     'tar cf - -C /uploads . | ssh -o StrictHostKeyChecking=accept-new -i /ssh/id_rsa $SERVER "cat > $BACKUP_WORKING_DIR/uploads_backup.tar"'
 echo "Adding md5sum checklist to backup"
 ssh $SERVER "find $BACKUP_WORKING_DIR -type f \( -not -name \"checklist.chk\" \) -exec md5sum \"{}\" + >$BACKUP_WORKING_DIR/checklist.chk"
-
-if [ $RESTORE_KEY = true ]; then
-    vault login -address=$VAULT_ADDR -method=github
-    PUBLIC_KEY=$(docker run --rm --volumes-from hint_hint busybox cat /etc/hint/token_key/public_key.der | base64 --wrap=0)
-    PRIVATE_KEY=$(docker run --rm --volumes-from hint_hint busybox cat /etc/hint/token_key/private_key.der | base64 --wrap=0)
-    echo "Writing private and public keys to $VAULT_PATH"
-    vault write -address=$VAULT_ADDR $VAULT_PATH public=$PUBLIC_KEY private=$PRIVATE_KEY
-    echo "$VAULT_PATH" | ssh $SERVER "cat > $BACKUP_WORKING_DIR/cipher_path"
-fi
 
 ssh $SERVER "tar -cf $BACKUP_PATH -C $BACKUP_WORKING_DIR ."
 echo "Backup complete, saved at $SERVER:$BACKUP_PATH"

--- a/backup/backup_remote
+++ b/backup/backup_remote
@@ -81,10 +81,14 @@ else
     RESTORE_KEY=false
 fi
 
+echo "Building backup container"
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+docker build -f $SCRIPT_DIR/Dockerfile -t mrcide/hint-backup:latest
+
 echo "Backing up postgres data"
 docker exec hint_db pg_dumpall -U postgres | ssh $SERVER "cat > $BACKUP_WORKING_DIR/db_dump.sql"
 echo "Backing up redis data"
-docker run --rm --volumes-from hint_redis busybox tar cf - -C /data . | ssh $SERVER "cat > $BACKUP_WORKING_DIR/redis_backup.tar"
+docker run --rm --volumes-from hint_redis -v $HOME/.ssh:/ssh mrcide/hint-backup:latest 'tar cf - -C /data . | ssh $SERVER -i /ssh/id_rsa "cat > $BACKUP_WORKING_DIR/redis_backup.tar"'
 echo "Backing up prerun data"
 docker run --rm --volumes-from hint_hintr busybox tar cf - -C /prerun . | ssh $SERVER "cat > $BACKUP_WORKING_DIR/prerun_backup.tar"
 echo "Backing up results data"

--- a/backup/backup_remote
+++ b/backup/backup_remote
@@ -83,18 +83,43 @@ fi
 
 echo "Building backup container"
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
-docker build -f $SCRIPT_DIR/Dockerfile -t mrcide/hint-backup:latest
+IMAGE_TAG=mrcide/hint-backup:latest
+docker build -t $IMAGE_TAG -f $SCRIPT_DIR/Dockerfile .
 
 echo "Backing up postgres data"
 docker exec hint_db pg_dumpall -U postgres | ssh $SERVER "cat > $BACKUP_WORKING_DIR/db_dump.sql"
 echo "Backing up redis data"
-docker run --rm --volumes-from hint_redis -v $HOME/.ssh:/ssh mrcide/hint-backup:latest 'tar cf - -C /data . | ssh $SERVER -i /ssh/id_rsa "cat > $BACKUP_WORKING_DIR/redis_backup.tar"'
+docker run --rm \
+    --volumes-from hint_redis \
+    -v $HOME/.ssh:/ssh \
+    -e SERVER=$SERVER \
+    -e BACKUP_WORKING_DIR=$BACKUP_WORKING_DIR \
+    $IMAGE_TAG sh -c \
+    'tar cf - -C /data . | ssh -o StrictHostKeyChecking=accept-new -i /ssh/id_rsa $SERVER "cat > $BACKUP_WORKING_DIR/redis_backup.tar"'
 echo "Backing up prerun data"
-docker run --rm --volumes-from hint_hintr busybox tar cf - -C /prerun . | ssh $SERVER "cat > $BACKUP_WORKING_DIR/prerun_backup.tar"
+docker run --rm \
+    --volumes-from hint_hintr \
+    -v $HOME/.ssh:/ssh \
+    -e SERVER=$SERVER \
+    -e BACKUP_WORKING_DIR=$BACKUP_WORKING_DIR \
+    $IMAGE_TAG sh -c \
+    'tar cf - -C /prerun . | ssh -o StrictHostKeyChecking=accept-new -i /ssh/id_rsa $SERVER "cat > $BACKUP_WORKING_DIR/prerun_backup.tar"'
 echo "Backing up results data"
-docker run --rm --volumes-from hint_hintr busybox tar cf - -C /results . | ssh $SERVER "cat > $BACKUP_WORKING_DIR/results_backup.tar"
+docker run --rm \
+    --volumes-from hint_hintr \
+    -v $HOME/.ssh:/ssh \
+    -e SERVER=$SERVER \
+    -e BACKUP_WORKING_DIR=$BACKUP_WORKING_DIR \
+    $IMAGE_TAG sh -c \
+    'tar cf - -C /results . | ssh -o StrictHostKeyChecking=accept-new -i /ssh/id_rsa $SERVER "cat > $BACKUP_WORKING_DIR/results_backup.tar"'
 echo "Backing up uploads data"
-docker run --rm --volumes-from hint_hintr busybox tar cf - -C /uploads . | ssh $SERVER "cat > $BACKUP_WORKING_DIR/uploads_backup.tar"
+docker run --rm \
+    --volumes-from hint_hintr \
+    -v $HOME/.ssh:/ssh \
+    -e SERVER=$SERVER \
+    -e BACKUP_WORKING_DIR=$BACKUP_WORKING_DIR \
+    $IMAGE_TAG sh -c \
+    'tar cf - -C /uploads . | ssh $SERVER "cat > $BACKUP_WORKING_DIR/uploads_backup.tar"'
 echo "Adding md5sum checklist to backup"
 ssh $SERVER "find $BACKUP_WORKING_DIR -type f \( -not -name \"checklist.chk\" \) -exec md5sum \"{}\" + >$BACKUP_WORKING_DIR/checklist.chk"
 

--- a/backup/backup_remote
+++ b/backup/backup_remote
@@ -119,7 +119,7 @@ docker run --rm \
     -e SERVER=$SERVER \
     -e BACKUP_WORKING_DIR=$BACKUP_WORKING_DIR \
     $IMAGE_TAG sh -c \
-    'tar cf - -C /uploads . | ssh $SERVER "cat > $BACKUP_WORKING_DIR/uploads_backup.tar"'
+    'tar cf - -C /uploads . | ssh -o StrictHostKeyChecking=accept-new -i /ssh/id_rsa $SERVER "cat > $BACKUP_WORKING_DIR/uploads_backup.tar"'
 echo "Adding md5sum checklist to backup"
 ssh $SERVER "find $BACKUP_WORKING_DIR -type f \( -not -name \"checklist.chk\" \) -exec md5sum \"{}\" + >$BACKUP_WORKING_DIR/checklist.chk"
 

--- a/backup/restore_remote
+++ b/backup/restore_remote
@@ -165,6 +165,9 @@ ssh $SERVER "mkdir $RESTORE_WORKING_DIR"
 trap clean_up ERR
 
 create_volumes
+ssh $SERVER "tar -xvf $RESTORE_PATH -C $RESTORE_WORKING_DIR"
+ssh $SERVER "md5sum --check $RESTORE_WORKING_DIR/checklist.chk"
+ssh $SERVER "$(declare -f assert_all_data_exists); assert_all_data_exists $RESTORE_WORKING_DIR"
 
 if $(ssh $SERVER "[ -f $RESTORE_WORKING_DIR/cipher_path ]"); then
     echo "Do you want to restore cipher keys from vault?"
@@ -175,9 +178,6 @@ if $(ssh $SERVER "[ -f $RESTORE_WORKING_DIR/cipher_path ]"); then
     fi
 fi
 
-ssh $SERVER "tar -xvf $RESTORE_PATH -C $RESTORE_WORKING_DIR"
-ssh $SERVER "md5sum --check $RESTORE_WORKING_DIR/checklist.chk"
-ssh $SERVER "$(declare -f assert_all_data_exists); assert_all_data_exists $RESTORE_WORKING_DIR"
 restore $SERVER $RESTORE_WORKING_DIR
 
 echo "Restore complete"

--- a/backup/restore_remote
+++ b/backup/restore_remote
@@ -133,7 +133,6 @@ wait_for_postgres() {
 }
 
 restore() {
-    create_volumes
     docker run --rm -d -v hint_db_data:/pgdata -e POSTGRES_PASSWORD=password -e PGDATA=/pgdata --name restore_pg postgres:10.3
     wait_for_postgres
     echo "Restoring database"
@@ -165,14 +164,14 @@ RESTORE_WORKING_DIR=$RESTORE_DIR/working
 ssh $SERVER "mkdir $RESTORE_WORKING_DIR"
 trap clean_up ERR
 
+create_volumes
+
 if $(ssh $SERVER "[ -f $RESTORE_WORKING_DIR/cipher_path ]"); then
     echo "Do you want to restore cipher keys from vault?"
     read -p "Restore keys? y/n" -n 1 -r
     echo
     if [[ $REPLY =~ ^[Yy]$ ]]; then
-        RESTORE_KEY=true
-    else
-        RESTORE_KEY=false
+        restore_key
     fi
 fi
 
@@ -180,9 +179,6 @@ ssh $SERVER "tar -xvf $RESTORE_PATH -C $RESTORE_WORKING_DIR"
 ssh $SERVER "md5sum --check $RESTORE_WORKING_DIR/checklist.chk"
 ssh $SERVER "$(declare -f assert_all_data_exists); assert_all_data_exists $RESTORE_WORKING_DIR"
 restore $SERVER $RESTORE_WORKING_DIR
-if [ $RESTORE_KEY = true ]; then
-    restore_key
-fi
 
 echo "Restore complete"
 ssh $SERVER "rm -rf $RESTORE_WORKING_DIR"


### PR DESCRIPTION
The remote backup script was tarring the file in the docker container then running the ssh command, meaning that the server was still running out of hard disk space. This PR will change that so that the data is piped to the remote server instead of being written to local disk.

This also tidies up the order of some stuff, it makes sure all things which require user interaction (using the vault) are done first. This is because the backup can take a long time so want to run it in a way that I don't have to sit watching it waiting for the user prompt at the end