### PR TITLE
Update paths to oauth secrets and use prod instance for preview naomi

### DIFF
--- a/config/dev.yml
+++ b/config/dev.yml
@@ -17,9 +17,9 @@ vault:
 hint:
   oauth2_login_method: true
   issue_report_url: VAULT:secret/hint/flow-webhooks/issue-report:url
-  oauth2_client_id: VAULT:secret/hint/oauth2/auth0:id
-  oauth2_client_secret: VAULT:secret/hint/oauth2/auth0:secret
-  oauth2_client_url: VAULT:secret/hint/oauth2/auth0:url
+  oauth2_client_id: VAULT:secret/hint/oauth2/development:id
+  oauth2_client_secret: VAULT:secret/hint/oauth2/development:secret
+  oauth2_client_url: VAULT:secret/hint/oauth2/development:url
   email:
     password: VAULT:secret/hint/email:password
 

--- a/config/dev.yml
+++ b/config/dev.yml
@@ -20,6 +20,7 @@ hint:
   oauth2_client_id: VAULT:secret/hint/oauth2/development:id
   oauth2_client_secret: VAULT:secret/hint/oauth2/development:secret
   oauth2_client_url: VAULT:secret/hint/oauth2/development:url
+  oauth2_client_audience: naomi
   email:
     password: VAULT:secret/hint/email:password
 

--- a/config/preview.yml
+++ b/config/preview.yml
@@ -20,5 +20,6 @@ hint:
   oauth2_client_id: VAULT:secret/hint/oauth2/production:id
   oauth2_client_secret: VAULT:secret/hint/oauth2/production:secret
   oauth2_client_url: VAULT:secret/hint/oauth2/production:url
+  oauth2_client_audience: naomi
   email:
     password: VAULT:secret/hint/email:password

--- a/config/preview.yml
+++ b/config/preview.yml
@@ -16,11 +16,9 @@ vault:
 
 hint:
   issue_report_url: VAULT:secret/hint/flow-webhooks/issue-report:url
-  oauth2_client_id: VAULT:secret/hint/oauth2/auth0:id
-  oauth2_client_secret: VAULT:secret/hint/oauth2/auth0:secret
-  oauth2_client_url: VAULT:secret/hint/oauth2/auth0:url
-  oauth2_client_adr_url: https://naomi-preview.dide.ic.ac.uk/resource-server
-  oauth2_client_audience: naomi
-  oauth2_login_method: false
+  oauth2_login_method: true
+  oauth2_client_id: VAULT:secret/hint/oauth2/production:id
+  oauth2_client_secret: VAULT:secret/hint/oauth2/production:secret
+  oauth2_client_url: VAULT:secret/hint/oauth2/production:url
   email:
     password: VAULT:secret/hint/email:password

--- a/config/staging.yml
+++ b/config/staging.yml
@@ -16,9 +16,9 @@ vault:
 
 hint:
   issue_report_url: VAULT:secret/hint/flow-webhooks/issue-report:url
-  oauth2_client_id: VAULT:secret/hint/oauth2/auth0:id
-  oauth2_client_secret: VAULT:secret/hint/oauth2/auth0:secret
-  oauth2_client_url: VAULT:secret/hint/oauth2/auth0:url
   oauth2_login_method: false
+  oauth2_client_id: VAULT:secret/hint/oauth2/development:id
+  oauth2_client_secret: VAULT:secret/hint/oauth2/development:secret
+  oauth2_client_url: VAULT:secret/hint/oauth2/development:url
   email:
     password: VAULT:secret/hint/email:password


### PR DESCRIPTION
After this PR we will have

* staging using standard/old login method (not OAuth)
* dev authentication with OAuth using our Auth0 instance (now called development)
* preview using the project balance/UNAIDS configured Auth0 instance (called production)
* production still using standard/old login

Note this removes the resource server config from preview as it looks like ADR won't get this in this year. The config here was incorrect anyway, we can always redeploy https://github.com/mrc-ide/hint-deploy/pull/53/files if someone wants to see the resource server working