### PR TITLE
Add auth0 configuration to prod

### DIFF
--- a/config/preview.yml
+++ b/config/preview.yml
@@ -17,9 +17,9 @@ vault:
 hint:
   issue_report_url: VAULT:secret/hint/flow-webhooks/issue-report:url
   oauth2_login_method: true
-  oauth2_client_id: VAULT:secret/hint/oauth2/production:id
-  oauth2_client_secret: VAULT:secret/hint/oauth2/production:secret
-  oauth2_client_url: VAULT:secret/hint/oauth2/production:url
+  oauth2_client_id: VAULT:secret/hint/oauth2/preview:id
+  oauth2_client_secret: VAULT:secret/hint/oauth2/preview:secret
+  oauth2_client_url: VAULT:secret/hint/oauth2/preview:url
   oauth2_client_audience: naomi
   email:
     password: VAULT:secret/hint/email:password

--- a/config/production.yml
+++ b/config/production.yml
@@ -2,6 +2,10 @@ hint:
   adr_url: https://adr.unaids.org/
   issue_report_url: VAULT:secret/hint/flow-webhooks/issue-report:url
   oauth2_login_method: false
+  oauth2_client_id: VAULT:secret/hint/oauth2/production:id
+  oauth2_client_secret: VAULT:secret/hint/oauth2/production:secret
+  oauth2_client_url: VAULT:secret/hint/oauth2/production:url
+  oauth2_client_audience: naomi
   email:
     password: VAULT:secret/hint/email:password
 

--- a/config/staging.yml
+++ b/config/staging.yml
@@ -15,6 +15,7 @@ vault:
       secret_id: $VAULT_AUTH_SECRET_ID
 
 hint:
+  oauth2_login_method: true
   issue_report_url: VAULT:secret/hint/flow-webhooks/issue-report:url
   oauth2_login_method: false
   oauth2_client_id: VAULT:secret/hint/oauth2/development:id


### PR DESCRIPTION
This doesn't turn on login with auth0 in production yet, once we get the go ahead after user migration is done we can switch `oauth2_login_method: true` in prod deploy and get this merged. After this we will have
* Dev and staging using auth0 but pointing to our development Auth0 tenant https://manage.auth0.com/dashboard/us/dev-xblynil1/
* Preview pointing to preview app in UNAIDS tenant (this will have same users as prod db, it is just a different app so we can test making configuration changes)
* Prod pointing to production app in UNAIDS tenant (atm disabled but all other config is in place)