### PR TITLE
Add labels to hintr container for controlling filebeat

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,9 @@ jobs:
           pip3 install -r requirements.txt
 
       - name: Tests
+        env:
+          VAULT_AUTH_ROLE_ID: ${{ secrets.VAULT_AUTH_ROLE_ID }}
+          VAULT_AUTH_SECRET_ID: ${{ secrets.VAULT_AUTH_SECRET_ID }}
         run: |
           pytest --cov=src
 
@@ -41,4 +44,7 @@ jobs:
           pycodestyle .
 
       - name: Upload coverage to Codecov
+        env:
+          VAULT_AUTH_ROLE_ID: ${{ secrets.VAULT_AUTH_ROLE_ID }}
+          VAULT_AUTH_SECRET_ID: ${{ secrets.VAULT_AUTH_SECRET_ID }}
         uses: codecov/codecov-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ constellation
 .coverage
 config/.last_deploy
 .idea
+config/other.yml

--- a/README.md
+++ b/README.md
@@ -41,6 +41,26 @@ Options:
 
 Once a configuration is set during `start`, it will be reused by subsequent commands (`stop`, `status`, `upgrade`, `user`, etc) and removed during `destroy`.  The configuration usage information is stored in `config/.last_deploy`.
 
+## Testing
+
+hint-deploy uses [AppRole](https://developer.hashicorp.com/vault/docs/auth/approle) to authenticate with the vault. To run tests locally you will need to set `VAULT_AUTH_ROLE_ID` and `VAULT_AUTH_SECRET_ID` to valid role-id and secret-it.
+
+To get them run
+
+```
+vault login -method=github
+vault read auth/approle/role/hint-deploy/role-id
+export VAULT_AUTH_ROLE_ID=role-id
+vault write -f auth/approle/role/hint-deploy/secret-id
+export VAULT_AUTH_SECRET_ID=secret-id
+```
+ensure they are available as env vars wherever you run pytest from. These are available to the CI as repo secrets.
+
+You can test it by trying to login via
+```
+vault write auth/approle/login role_id=$VAULT_AUTH_ROLE_ID secret_id=$VAULT_AUTH_SECRET_ID
+```
+
 ## Deployment onto the servers
 
 We have two copies of hint deployed:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-constellation==0.0.8
+constellation==0.0.13
 docopt
 pytest
 requests

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -130,9 +130,12 @@ def hint_constellation(cfg):
     if cfg.hintr_use_mock_model:
         hintr_env["USE_MOCK_MODEL"] = "true"
     hintr_ports = [8888] if cfg.hint_expose else None
+    ## See https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover-hints.html
+    ## for details of how labels are used by filebeat autodiscover
+    labels = {"co.elastic.logs/json.add_error_key": True}
     hintr = constellation.ConstellationContainer(
         "hintr", hintr_ref, args=hintr_args, mounts=hintr_mounts,
-        ports=hintr_ports, environment=hintr_env)
+        ports=hintr_ports, environment=hintr_env, labels=labels)
 
     # 4. hint
     hint_ref = constellation.ImageReference("mrcide", "hint",

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -130,9 +130,9 @@ def hint_constellation(cfg):
     if cfg.hintr_use_mock_model:
         hintr_env["USE_MOCK_MODEL"] = "true"
     hintr_ports = [8888] if cfg.hint_expose else None
-    ## See https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover-hints.html
-    ## for details of how labels are used by filebeat autodiscover
-    labels = {"co.elastic.logs/json.add_error_key": True}
+    # See https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover-hints.html
+    # for details of how labels are used by filebeat autodiscover
+    labels = {"co.elastic.logs/json.add_error_key": "true"}
     hintr = constellation.ConstellationContainer(
         "hintr", hintr_ref, args=hintr_args, mounts=hintr_mounts,
         ports=hintr_ports, environment=hintr_env, labels=labels)

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -130,7 +130,7 @@ def hint_constellation(cfg):
     if cfg.hintr_use_mock_model:
         hintr_env["USE_MOCK_MODEL"] = "true"
     hintr_ports = [8888] if cfg.hint_expose else None
-    # See https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover-hints.html
+    # See https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover-hints.html # noqa
     # for details of how labels are used by filebeat autodiscover
     labels = {"co.elastic.logs/json.add_error_key": "true"}
     hintr = constellation.ConstellationContainer(


### PR DESCRIPTION
This requies https://github.com/reside-ic/constellation/pull/16

Can test this by running
```
docker run  -l co.elastic.logs/json.add_error_key=true -it --rm --name naughty_rubin busybox echo '{"foo":"bar", "error_msg": "error opening file"}'
```
from a machine with filebeat running and see in the logs by searcing for `container.name: "naughty_rubin"`
![Screenshot_20221115_175441](https://user-images.githubusercontent.com/39248272/201991360-6eaf4963-cc58-4a7a-bf4d-f9f4145d72ac.png)

it will unpack the JSON content of the log into fields called `json.key`. This option itself `add_error_key` you can see here https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-log.html#filebeat-input-log-config-json it will add error info if the json fails to unpack. But having this set also triggers the autodiscover to unpack the json in the first place
