### PR TITLE
mrc-3845: Migrate all stored emails to lower case

### DIFF
--- a/scripts/lowercase_user_ids.groovy
+++ b/scripts/lowercase_user_ids.groovy
@@ -23,16 +23,19 @@ class Profile {
             println "Not migrating " + this.old_id + " as account already exists for id " + this.new_id
             return
         }
+        def new_id = this.new_id
+        def old_id = this.old_id
         def updateSql = """
-        INSERT into users (id, username) VALUES (:new_id, :new_id);
-        UPDATE user_session set user_id = :new_id where user_id = :old_id;
-        UPDATE adr_key set user_id = :new_id where user_id = :old_id;
-        UPDATE project set shared_by = :new_id where user_id = :old_id;
-        UPDATE project set user_id = :new_id where user_id = :old_id;
+        INSERT into users (id, username) VALUES ('${new_id}', '${new_id}');
+        UPDATE user_session set user_id = '${new_id}' where user_id = '${old_id}';
+        UPDATE adr_key set user_id = '${new_id}' where user_id = '${old_id}';
+        UPDATE project set shared_by = '${new_id}' where user_id = '${old_id}';
+        UPDATE project set user_id = '${new_id}' where user_id = '${old_id}';
 
-        DELETE from users where id = :old_id;
+        DELETE from users where id = '${old_id}';
         """
-        //con.execute([new_id: this.new_id, old_id: this.new_id], updateSql)
+        def sql = updateSql.toString()
+        con.execute sql
         println "Migrated " + this.old_id + " to " + this.new_id
         return
     }

--- a/scripts/lowercase_user_ids.groovy
+++ b/scripts/lowercase_user_ids.groovy
@@ -12,9 +12,10 @@ class Profile {
     String old_id;
     String new_id;
 
-    Profile(id) {
+    Profile(con, id) {
+        this.con = con
         this.old_id = id
-        this.new_id = toLowerCase(this.old_id)
+        this.new_id = this.old_id.toLowerCase()
     }
 
     void migrate() {
@@ -22,13 +23,15 @@ class Profile {
             println "Not migrating " + this.old_id + " as account already exists for id " + this.new_id
             return
         }
-        def updateSql = "INSERT into users (id, username) VALUES (:new_id, :new_id);
+        def updateSql = """
+        INSERT into users (id, username) VALUES (:new_id, :new_id);
         UPDATE user_session set user_id = :new_id where user_id = :old_id;
         UPDATE adr_key set user_id = :new_id where user_id = :old_id;
         UPDATE project set shared_by = :new_id where user_id = :old_id;
         UPDATE project set user_id = :new_id where user_id = :old_id;
 
-        DELETE from users where id = :old_id;"
+        DELETE from users where id = :old_id;
+        """
         //con.execute([new_id: this.new_id, old_id: this.new_id], updateSql)
         println "Migrated " + this.old_id + " to " + this.new_id
         return

--- a/scripts/lowercase_user_ids.groovy
+++ b/scripts/lowercase_user_ids.groovy
@@ -1,0 +1,57 @@
+// See ticket
+// https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-3845
+// for details
+
+@GrabConfig(systemClassLoader=true)
+@Grab(group='org.postgresql', module='postgresql',  version='9.4-1205-jdbc42')
+@Grab(group='ch.qos.logback', module='logback-classic', version='1.0.13')
+import groovy.sql.Sql
+
+class Profile {
+    def con;
+    String old_id;
+    String new_id;
+
+    Profile(id) {
+        this.old_id = id
+        this.new_id = toLowerCase(this.old_id)
+    }
+
+    void migrate() {
+        if (this.con.firstRow('SELECT count(*) as cnt FROM users WHERE id =:id', id:new_id)?.cnt > 0) {
+            println "Not migrating " + this.old_id + " as account already exists for id " + this.new_id
+            return
+        }
+        def updateSql = "INSERT into users (id, username) VALUES (:new_id, :new_id);
+        UPDATE user_session set user_id = :new_id where user_id = :old_id;
+        UPDATE adr_key set user_id = :new_id where user_id = :old_id;
+        UPDATE project set shared_by = :new_id where user_id = :old_id;
+        UPDATE project set user_id = :new_id where user_id = :old_id;
+
+        DELETE from users where id = :old_id;"
+        //con.execute([new_id: this.new_id, old_id: this.new_id], updateSql)
+        println "Migrated " + this.old_id + " to " + this.new_id
+        return
+    }
+}
+
+def dbUrl      = "jdbc:postgresql://hint_db/hint"
+def dbUser     = "hintuser"
+def dbPassword = "changeme"
+def dbDriver   = "org.postgresql.Driver"
+def con = Sql.newInstance(dbUrl, dbUser, dbPassword, dbDriver)
+
+def users = []
+try {
+    con.eachRow("SELECT id FROM users WHERE id ~ '[A-Z]';") { row ->
+        users << new Profile(con, row.id)
+    }
+
+    con.withTransaction {
+        users.each { user ->
+            user.migrate()
+        }
+    }
+} finally {
+    con.close()
+}

--- a/scripts/run_lowercase_user_ids
+++ b/scripts/run_lowercase_user_ids
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -ex
+
+docker run --rm -v "$PWD":/home/groovy/scripts --network=hint_nw -w /home/groovy/scripts groovy:4.0.4-jdk11-alpine groovy lowercase_user_ids.groovy


### PR DESCRIPTION
I ran this on dev and confirmed the output

```
Migrated James@example.com to james@example.com
```

And now logging in as this user everything looks to work. Would be handy if you can double check this. Break the account like mentioned in the ticket, run this script to fix it and confirm it works.