### PR TITLE
mrc-3838: Deploy load balancer as part of hint-deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ constellation
 config/.last_deploy
 .idea
 config/other.yml
+.vscode

--- a/config/hint.yml
+++ b/config/hint.yml
@@ -13,8 +13,13 @@ hint:
     config: "hint_config"
   expose: true
 
+hintr-loadbalancer:
+  tag: "main"
+  api_instances: 1
+
 hintr:
   tag: "master"
+  port: 8888
   workers: 2
   calibrate_workers: 1
   volumes:

--- a/config/production.yml
+++ b/config/production.yml
@@ -5,9 +5,12 @@ hint:
   email:
     password: VAULT:secret/hint/email:password
 
+hintr-loadbalancer:
+  api_instances: 3
+
 hintr:
   workers: 5
-  calibrate_workers: 2 
+  calibrate_workers: 2
 
 proxy:
   host: naomi.unaids.org

--- a/src/hint_cli.py
+++ b/src/hint_cli.py
@@ -171,7 +171,7 @@ def main(argv=None):
         save_config(path, config_name, cfg)
     elif action == "stop":
         verify_data_loss(action, args, cfg)
-        hint_stop(obj)
+        hint_stop(obj, args)
         if args["remove_volumes"]:
             remove_config(path)
     else:

--- a/src/hint_cli.py
+++ b/src/hint_cli.py
@@ -172,9 +172,8 @@ def main(argv=None):
     elif action == "stop":
         verify_data_loss(action, args, cfg)
         hint_stop(obj)
+        if args["remove_volumes"]:
+            remove_config(path)
     else:
         verify_data_loss(action, args, cfg)
         obj.__getattribute__(action)(**args)
-
-        if action == "stop" and args["remove_volumes"]:
-            remove_config(path)

--- a/src/hint_cli.py
+++ b/src/hint_cli.py
@@ -33,7 +33,8 @@ from src.hint_deploy import \
     hint_start, \
     hint_upgrade_hintr, \
     hint_upgrade_all, \
-    hint_user
+    hint_user, \
+    hint_stop
 
 
 # Returned options are passed to constellation and override
@@ -168,6 +169,9 @@ def main(argv=None):
         verify_data_loss(action, args, cfg)
         hint_start(obj, cfg, args)
         save_config(path, config_name, cfg)
+    elif action == "stop":
+        verify_data_loss(action, args, cfg)
+        hint_stop(obj)
     else:
         verify_data_loss(action, args, cfg)
         obj.__getattribute__(action)(**args)

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -150,7 +150,8 @@ def hint_constellation(cfg):
     hintr_loadbalancer_ref = cfg.hintr_loadbalancer_ref
     hintr_loadbalancer_ports = [8888] if cfg.hint_expose else None
     load_balancer = constellation.ConstellationContainer(
-        "hintr", hintr_loadbalancer_ref, ports=hintr_loadbalancer_ports)
+        "hintr", hintr_loadbalancer_ref, ports=hintr_loadbalancer_ports,
+        labels=labels)
 
     # 5. hint
     hint_ref = constellation.ImageReference("mrcide", "hint",

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -143,8 +143,8 @@ def hint_constellation(cfg):
     # for details of how labels are used by filebeat autodiscover
     labels = {"co.elastic.logs/json.add_error_key": "true"}
     hintr = constellation.ConstellationService(
-        "hintr_api", hintr_ref, cfg.api_instances, args=hintr_args, mounts=hintr_mounts,
-        environment=hintr_env, labels=labels)
+        "hintr_api", hintr_ref, cfg.api_instances, args=hintr_args,
+        mounts=hintr_mounts, environment=hintr_env, labels=labels)
 
     # 4. hintr load balancer
     hintr_loadbalancer_ref = cfg.hintr_loadbalancer_ref
@@ -359,6 +359,8 @@ def loadbalancer_configure(constellation):
         loadbalancer, ["configure_backend", "-p", str(cfg.hintr_port)] + args)
 
 # It can take a while for the container to come up
+
+
 def wait(f, message, timeout=30, poll=0.1):
     for i in range(math.ceil(timeout / poll)):
         try:

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -257,7 +257,7 @@ def hint_stop(obj, args):
     docker_util.container_stop(
         loadbalancer_container, True, loadbalancer_container.name)
     docker_util.container_remove_wait(loadbalancer_container)
-    obj.stop(args)
+    obj.stop(**args)
 
 
 def pull_migrate_image(db_tag):

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -359,8 +359,6 @@ def loadbalancer_configure(constellation):
         loadbalancer, ["configure_backend", "-p", str(cfg.hintr_port)] + args)
 
 # It can take a while for the container to come up
-
-
 def wait(f, message, timeout=30, poll=0.1):
     for i in range(math.ceil(timeout / poll)):
         try:

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -111,7 +111,7 @@ class HintConfig:
 
 
 def hint_constellation(cfg):
-    # 1. Redis
+    # Redis
     redis_ref = constellation.ImageReference("library", "redis",
                                              cfg.redis_tag)
     redis_mounts = [constellation.ConstellationMount("redis", "/data")]
@@ -120,14 +120,14 @@ def hint_constellation(cfg):
         "redis", redis_ref, mounts=redis_mounts, args=redis_args,
         configure=redis_configure)
 
-    # 2. The db
+    # The db
     db_ref = constellation.ImageReference(
         "mrcide", "hint-db", cfg.db_tag)
     db_mounts = [constellation.ConstellationMount("db", "/pgdata")]
     db = constellation.ConstellationContainer(
         "db", db_ref, mounts=db_mounts, configure=db_configure)
 
-    # 3. hintr
+    # hintr
     hintr_ref = cfg.hintr_ref
     hintr_args = ["--workers=0",
                   "--results-dir=/results",
@@ -146,14 +146,14 @@ def hint_constellation(cfg):
         "hintr_api", hintr_ref, cfg.api_instances, args=hintr_args,
         mounts=hintr_mounts, environment=hintr_env, labels=labels)
 
-    # 4. hintr load balancer
+    # hintr load balancer
     hintr_loadbalancer_ref = cfg.hintr_loadbalancer_ref
     hintr_loadbalancer_ports = [8888] if cfg.hint_expose else None
     load_balancer = constellation.ConstellationContainer(
         "hintr", hintr_loadbalancer_ref, ports=hintr_loadbalancer_ports,
         labels=labels)
 
-    # 5. hint
+    # hint
     hint_ref = constellation.ImageReference("mrcide", "hint",
                                             cfg.hint_tag)
     hint_mounts = [constellation.ConstellationMount("uploads", "/uploads"),
@@ -163,7 +163,7 @@ def hint_constellation(cfg):
         "hint", hint_ref, mounts=hint_mounts, ports=hint_ports,
         configure=hint_configure)
 
-    # 6. proxy
+    # proxy
     proxy_ref = constellation.ImageReference("mrcide", "hint-proxy", "latest")
     proxy_ports = [cfg.proxy_port_http, cfg.proxy_port_https]
     proxy_args = ["hint:8080",
@@ -174,14 +174,14 @@ def hint_constellation(cfg):
         "proxy", proxy_ref, ports=proxy_ports, args=proxy_args,
         configure=proxy_configure)
 
-    # 7. calibrate worker
+    # calibrate worker
     worker_ref = cfg.hintr_worker_ref
     calibrate_worker_args = ["--calibrate-only"]
     calibrate_worker = constellation.ConstellationService(
         "calibrate_worker", worker_ref, cfg.hintr_calibrate_workers,
         args=calibrate_worker_args, mounts=hintr_mounts, environment=hintr_env)
 
-    # 9. hintr workers
+    # hintr workers
     worker = constellation.ConstellationService(
         "worker", worker_ref, cfg.hintr_workers,
         mounts=hintr_mounts, environment=hintr_env)

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -207,7 +207,7 @@ def hint_start(obj, cfg, args):
         print("Adding test user '{}'".format(email))
         hint_user(cfg, "add-user", email, pull, "password")
 
-    loadbalancer_configure(obj)
+    loadbalancer_register_hintr_api(obj)
 
 
 def hint_upgrade_hintr(obj):
@@ -238,13 +238,13 @@ def hint_upgrade_hintr(obj):
 
     obj.start(subset=[loadbalancer.name, hintr_api.name,
               calibrate_worker.name, worker.name])
-    loadbalancer_configure(obj)
+    loadbalancer_register_hintr_api(obj)
 
 
 def hint_upgrade_all(obj, db_tag):
     pull_migrate_image(db_tag)
     obj.restart(pull_images=True)
-    loadbalancer_configure(obj)
+    loadbalancer_register_hintr_api(obj)
 
 
 def hint_stop(obj, args):
@@ -362,7 +362,7 @@ def proxy_configure(container, cfg):
         docker_util.exec_safely(container, args)
 
 
-def loadbalancer_configure(constellation):
+def loadbalancer_register_hintr_api(constellation):
     print("[hintr] Configuring loadbalancer")
     cfg = constellation.data
     loadbalancer = constellation.containers.get("hintr", cfg.prefix)

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -246,7 +246,7 @@ def hint_upgrade_all(obj, db_tag):
     loadbalancer_configure(obj)
 
 
-def hint_stop(obj):
+def hint_stop(obj, args):
     # Loadbalancer can take >10s to stop if we stop it via
     # docker stop making the ./hint stop error
     # We don't rely on saving any data from the loadbalancer
@@ -257,6 +257,7 @@ def hint_stop(obj):
     docker_util.container_stop(
         loadbalancer_container, True, loadbalancer_container.name)
     docker_util.container_remove_wait(loadbalancer_container)
+    obj.stop(args)
 
 
 def pull_migrate_image(db_tag):

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -373,9 +373,8 @@ def loadbalancer_configure(constellation):
     docker_util.exec_safely(
         loadbalancer, ["configure_backend", "-p", str(cfg.hintr_port)] + args)
 
+
 # It can take a while for the container to come up
-
-
 def wait(f, message, timeout=30, poll=0.1):
     for i in range(math.ceil(timeout / poll)):
         try:

--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -230,7 +230,7 @@ def hint_upgrade_hintr(obj):
                 print("Stopping {}".format(container.name))
                 container.exec_run(["hintr_stop"])
             docker_util.container_remove_wait(container)
-    print("Stopping {}".format(loadbalancer_container.name))
+    print("Killing {}".format(loadbalancer_container.name))
     docker_util.container_stop(
         loadbalancer_container, True, loadbalancer_container.name)
     docker_util.container_remove_wait(loadbalancer_container)
@@ -244,6 +244,19 @@ def hint_upgrade_all(obj, db_tag):
     pull_migrate_image(db_tag)
     obj.restart(pull_images=True)
     loadbalancer_configure(obj)
+
+
+def hint_stop(obj):
+    # Loadbalancer can take >10s to stop if we stop it via
+    # docker stop making the ./hint stop error
+    # We don't rely on saving any data from the loadbalancer
+    # so we can just kill the loadbalancer
+    loadbalancer = obj.containers.find("hintr")
+    loadbalancer_container = loadbalancer.get(obj.prefix)
+    print("Killing {}".format(loadbalancer_container.name))
+    docker_util.container_stop(
+        loadbalancer_container, True, loadbalancer_container.name)
+    docker_util.container_remove_wait(loadbalancer_container)
 
 
 def pull_migrate_image(db_tag):

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -91,7 +91,8 @@ def test_args_passed_to_start():
 
 
 def test_other_args_passed_to_start():
-    with mock.patch('src.hint_deploy.constellation.Constellation', autospec=True) as obj:
+    with mock.patch('src.hint_deploy.constellation.Constellation',
+                    autospec=True) as obj:
         instance = obj.return_value
         hint_cli.main(["status"])
         assert instance.status.called

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -2,6 +2,7 @@ import io
 import pytest
 import string
 
+from constellation import Constellation
 from contextlib import redirect_stdout
 from unittest import mock
 
@@ -89,13 +90,11 @@ def test_args_passed_to_start():
     assert f.call_args[0][2] == {"pull_images": True}
 
 
-# This *should* work as far as I can see but I don't see how to make it.
 def test_other_args_passed_to_start():
-    pytest.skip("not working")
-    with mock.patch('constellation.Constellation') as obj:
+    with mock.patch('src.hint_deploy.constellation.Constellation', autospec=True) as obj:
+        instance = obj.return_value
         hint_cli.main(["status"])
-
-    assert obj.status.called
+        assert instance.status.called
 
 
 def test_verify_data_loss_silent_if_no_loss():

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -31,7 +31,7 @@ def test_start_hint():
     obj = hint_deploy.hint_constellation(cfg)
     obj.status()
     obj.start()
-    hint_deploy.loadbalancer_configure(obj)
+    hint_deploy.loadbalancer_register_hintr_api(obj)
 
     res = s.get("http://localhost:8080")
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -178,7 +178,7 @@ def test_update_hintr_and_all():
     assert "Pulling docker image hintr" in p
     assert "Pulling docker image hintr_api" in p
     assert "Pulling docker image db-migrate" not in p
-    assert "Stopping hint_hintr" in p
+    assert "Killing hint_hintr" in p
     assert "Stopping hint_hintr_api_" in p
     assert "Starting hintr" in p
     assert "Starting *service* hintr_api" in p
@@ -279,3 +279,23 @@ def test_start_pulls_db_migrate():
     assert "Pulling docker image db-migrate" not in p
 
     obj.destroy()
+
+
+def test_stop_kills_loadbalancer():
+    hint_cli.main(["start"])
+
+    f = io.StringIO()
+    with redirect_stdout(f):
+        hint_cli.main(["stop"])
+
+    p = f.getvalue()
+    assert "Killing hint_hintr" in p
+
+    assert not docker_util.container_exists("hint_hintr")
+    assert not docker_util.container_exists("hint_db")
+    assert not docker_util.container_exists("hint_redis")
+    assert not docker_util.container_exists("hint_hint")
+    assert len(docker_util.containers_matching("hint_hintr_api_", False)) == 0
+    assert len(docker_util.containers_matching("hint_worker_", False)) == 0
+    assert len(docker_util.containers_matching(
+        "hint_calibrate_worker_", False)) == 0

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -20,6 +20,8 @@ def test_start_hint():
     obj = hint_deploy.hint_constellation(cfg)
     obj.status()
     obj.start()
+    hint_deploy.loadbalancer_configure(obj, cfg)
+    time.sleep(5)  # Wait for loadbalancer to reload config
 
     res = requests.get("http://localhost:8080")
 
@@ -39,6 +41,7 @@ def test_start_hint():
     assert docker_util.container_exists("hint_redis")
     assert docker_util.container_exists("hint_hintr")
     assert docker_util.container_exists("hint_hint")
+    assert len(docker_util.containers_matching("hint_hintr_api_", False)) == 1
     assert len(docker_util.containers_matching("hint_worker_", False)) == 2
     assert len(docker_util.containers_matching(
         "hint_calibrate_worker_", False)) == 1
@@ -78,7 +81,7 @@ def test_start_hint():
              '"http://localhost:8888/hintr/worker/status"),' + \
              '"text", encoding="UTF-8"))'
     args = ["Rscript", "-e", script]
-    hintr = obj.containers.get("hintr", obj.prefix)
+    hintr = obj.containers.get("hintr_api", obj.prefix)[0]
     result = docker_util.exec_safely(hintr, args).output
     logs = result.decode("UTF-8")
     data = json.loads(logs)["data"]
@@ -95,6 +98,7 @@ def test_start_hint():
     assert not docker_util.container_exists("hint_redis")
     assert not docker_util.container_exists("hint_hintr")
     assert not docker_util.container_exists("hint_hint")
+    assert len(docker_util.containers_matching("hint_hintr_api_", False)) == 0
     assert len(docker_util.containers_matching("hint_worker_", False)) == 0
     assert len(docker_util.containers_matching(
         "hint_calibrate_worker_", False)) == 0
@@ -177,6 +181,8 @@ def test_update_hintr_and_all():
     assert docker_util.container_exists("hint_redis")
     assert docker_util.container_exists("hint_hintr")
     assert docker_util.container_exists("hint_hint")
+    assert len(docker_util.containers_matching("hint_hintr_api_", False)) == 1
+    assert len(docker_util.containers_matching("hint_hintr_api_", True)) == 2
     assert len(docker_util.containers_matching("hint_worker_", False)) == 2
     assert len(docker_util.containers_matching("hint_worker_", True)) == 4
     assert len(docker_util.containers_matching(
@@ -213,6 +219,7 @@ def test_update_hintr_and_all():
     assert docker_util.container_exists("hint_redis")
     assert docker_util.container_exists("hint_hintr")
     assert docker_util.container_exists("hint_hint")
+    assert len(docker_util.containers_matching("hint_hintr_api_", False)) == 1
     assert len(docker_util.containers_matching("hint_worker_", False)) == 2
     assert len(docker_util.containers_matching(
         "hint_calibrate_worker_", False)) == 1


### PR DESCRIPTION
This is using https://github.com/mrc-ide/hintr-loadbalancer to loadbalance multiple hintr instances. At the moment this just brings up 1 hintr instance

This should mean hintr is less of a bottle neck in deployed applications. See https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-3766/Investigate-system-load-issues for initial investigation

This is currently deployed on dev with 2 copies of hintr running, it is looking to be working nicely there!

Interesting parts of loadbalancer setup to review are 
* config - https://github.com/mrc-ide/hintr-loadbalancer/blob/main/haproxy.cfg
* backend configuration script - https://github.com/mrc-ide/hintr-loadbalancer/blob/main/bin/configure_backend

I will take a look now at using leastcon vs roundrobin