### PR TITLE
Add SSO config for dev and staging

### DIFF
--- a/config/dev.yml
+++ b/config/dev.yml
@@ -15,12 +15,15 @@ vault:
       secret_id: $VAULT_AUTH_SECRET_ID
 
 hint:
+  adr_url: https://dev.adr.fjelltopp.org/
   oauth2_login_method: true
   issue_report_url: VAULT:secret/hint/flow-webhooks/issue-report:url
   oauth2_client_id: VAULT:secret/hint/oauth2/development:id
   oauth2_client_secret: VAULT:secret/hint/oauth2/development:secret
   oauth2_client_url: VAULT:secret/hint/oauth2/development:url
-  oauth2_client_audience: naomi
+  oauth2_client_adr_server_url: VAULT:secret/hint/oauth2/development:adr_server_url
+  oauth2_client_scope: VAULT:secret/hint/oauth2/development:scope
+  oauth2_client_audience: VAULT:secret/hint/oauth2/development:audience
   email:
     password: VAULT:secret/hint/email:password
 

--- a/config/staging.yml
+++ b/config/staging.yml
@@ -15,10 +15,14 @@ vault:
       secret_id: $VAULT_AUTH_SECRET_ID
 
 hint:
+  adr_url: https://dev.adr.fjelltopp.org/
   oauth2_login_method: true
   issue_report_url: VAULT:secret/hint/flow-webhooks/issue-report:url
   oauth2_client_id: VAULT:secret/hint/oauth2/development:id
   oauth2_client_secret: VAULT:secret/hint/oauth2/development:secret
   oauth2_client_url: VAULT:secret/hint/oauth2/development:url
+  oauth2_client_adr_server_url: VAULT:secret/hint/oauth2/development:adr_server_url
+  oauth2_client_scope: VAULT:secret/hint/oauth2/development:scope
+  oauth2_client_audience: VAULT:secret/hint/oauth2/development:audience
   email:
     password: VAULT:secret/hint/email:password


### PR DESCRIPTION
This PR will update SSO config for dev and staging instances to work with SSO without needing an API key to pull data from the ADR

I've deployed this on dev and checked that is is working