### PR TITLE
Update backup scripts to use hint container now running multiple hintr instances

### DIFF
--- a/backup/backup
+++ b/backup/backup
@@ -38,8 +38,8 @@ fi
 
 docker exec hint-db pg_dumpall -U postgres >$BACKUP_WORKING_DIR/db_dump.sql
 docker run --rm --volumes-from hint-redis -v $BACKUP_WORKING_DIR:/backup busybox tar -cf /backup/redis_backup.tar -C /data .
-docker run --rm --volumes-from hint-hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -cf /backup/results_backup.tar -C /results .
-docker run --rm --volumes-from hint-hintr -v $BACKUP_WORKING_DIR:/backup busybox tar -cf /backup/uploads_backup.tar -C /uploads .
+docker run --rm --volumes-from hint-hint -v $BACKUP_WORKING_DIR:/backup busybox tar -cf /backup/results_backup.tar -C /results .
+docker run --rm --volumes-from hint-hint -v $BACKUP_WORKING_DIR:/backup busybox tar -cf /backup/uploads_backup.tar -C /uploads .
 find $BACKUP_WORKING_DIR -type f \( -not -name "checklist.chk" \) -exec md5sum "{}" + >$BACKUP_WORKING_DIR/checklist.chk
 
 if [ $RESTORE_KEY = true ]; then

--- a/backup/backup_remote
+++ b/backup/backup_remote
@@ -101,7 +101,7 @@ docker run --rm \
 
 echo "*** Backing up results data"
 docker run --rm \
-    --volumes-from hint-hintr \
+    --volumes-from hint-hint \
     -v $HOME/.ssh:/ssh \
     -e SERVER=$SERVER \
     -e BACKUP_DIR=$BACKUP_DIR \
@@ -110,7 +110,7 @@ docker run --rm \
 
 echo "*** Backing up uploads data"
 docker run --rm \
-    --volumes-from hint-hintr \
+    --volumes-from hint-hint \
     -v $HOME/.ssh:/ssh \
     -e SERVER=$SERVER \
     -e BACKUP_DIR=$BACKUP_DIR \


### PR DESCRIPTION
When we last used this backup script there was only 1 instance of hintr running and I was using this with `volumes-from` flag. Now we have multiple hintrs I can't do this, so just updating to use `volumes-from` hint instead.