### PR TITLE
[NM-115] Update deployment to use new arg format for starting workers

### DIFF
--- a/src/hint_deploy.py
+++ b/src/hint_deploy.py
@@ -170,7 +170,7 @@ def hint_constellation(cfg):
 
     # calibrate worker
     worker_ref = cfg.hintr_worker_ref
-    calibrate_worker_args = ["--calibrate-only"]
+    calibrate_worker_args = ["--worker-config=calibrate_only"]
     calibrate_worker = constellation.ConstellationService(
         "calibrate-worker", worker_ref, cfg.hintr_calibrate_workers,
         args=calibrate_worker_args, mounts=hintr_mounts, environment=hintr_env)


### PR DESCRIPTION
Now instead of passing args `--calibrate-only` we say what type of worker we want to start up. By default, if not specified it will start up a "localhost" worker which is the default name.